### PR TITLE
Fix profit calculation for item extras

### DIFF
--- a/lib/pages/offer_detail_page.dart
+++ b/lib/pages/offer_detail_page.dart
@@ -204,9 +204,14 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
             double accessoryCost = (accessory != null) ? accessory.price * item.quantity : 0;
             double extras = (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
 
-            double total = profileCost + glassCost + blindCost + mechanismCost + accessoryCost + extras;
-            double finalPrice = item.manualPrice ??
-                total * (1 + offer.profitPercent / 100);
+            double base = profileCost + glassCost + blindCost + mechanismCost + accessoryCost;
+            double total = base + extras;
+            double finalPrice;
+            if (item.manualPrice != null) {
+              finalPrice = item.manualPrice!;
+            } else {
+              finalPrice = base * (1 + offer.profitPercent / 100) + extras;
+            }
             double profitAmount = finalPrice - total;
 
             return Card(
@@ -307,9 +312,15 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                     : 0;
                 double accessoryCost = (accessory != null) ? accessory.price * item.quantity : 0;
                 double extras = (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
-                double base = profileCost + glassCost + blindCost + mechanismCost + accessoryCost + extras;
-                double finalPrice = item.manualPrice ?? base * (offer.profitPercent / 100 + 1);
-                itemsBase += base;
+                double base = profileCost + glassCost + blindCost + mechanismCost + accessoryCost;
+                double total = base + extras;
+                double finalPrice;
+                if (item.manualPrice != null) {
+                  finalPrice = item.manualPrice!;
+                } else {
+                  finalPrice = base * (offer.profitPercent / 100 + 1) + extras;
+                }
+                itemsBase += total;
                 itemsFinal += finalPrice;
               }
               double extrasTotal = offer.extraCharges.fold(0, (p, e) => p + e.amount);

--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -71,11 +71,18 @@ Future<void> printOfferPdf({
         ? mechanism.price * item.quantity * item.openings
         : 0;
     final accessoryCost =
-    accessory != null ? accessory.price * item.quantity : 0;
+        accessory != null ? accessory.price * item.quantity : 0;
     final extras = (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
 
-    final total = profileCost + glassCost + blindCost + mechanismCost + accessoryCost + extras;
-    final price = item.manualPrice ?? total * (1 + offer.profitPercent / 100);
+    final base =
+        profileCost + glassCost + blindCost + mechanismCost + accessoryCost;
+    final total = base + extras;
+    double price;
+    if (item.manualPrice != null) {
+      price = item.manualPrice!;
+    } else {
+      price = base * (1 + offer.profitPercent / 100) + extras;
+    }
 
     itemsFinal += price;
   }
@@ -185,8 +192,14 @@ Future<void> printOfferPdf({
           final accessoryCost = accessory != null ? accessory.price * item.quantity : 0;
           final extras = (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
 
-          final total = profileCost + glassCost + blindCost + mechanismCost + accessoryCost + extras;
-          final finalPrice = item.manualPrice ?? total * (1 + offer.profitPercent / 100);
+          final base = profileCost + glassCost + blindCost + mechanismCost + accessoryCost;
+          final total = base + extras;
+          double finalPrice;
+          if (item.manualPrice != null) {
+            finalPrice = item.manualPrice!;
+          } else {
+            finalPrice = base * (1 + offer.profitPercent / 100) + extras;
+          }
           final pricePerPiece = finalPrice / item.quantity;
 
           final vAdapters = item.verticalAdapters.map((a) => a ? 'Adapter' : 'T').join(', ');


### PR DESCRIPTION
## Summary
- prevent additional costs from being increased by profit margin
- update offer summary calculations
- update PDF generation logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879193702a08324b6e647fd3f1fd856