### PR TITLE
Fix extras display in PDF

### DIFF
--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -234,6 +234,12 @@ Future<void> printOfferPdf({
             if (blind != null) pw.Text('Blind: ${blind.name}'),
             if (mechanism != null) pw.Text('Mechanism: ${mechanism.name}'),
             if (accessory != null) pw.Text('Accessory: ${accessory.name} = €${accessory.price}'),
+            if (item.extra1Price != null)
+              pw.Text(
+                  '${item.extra1Desc ?? 'Additional 1'}: €${item.extra1Price!.toStringAsFixed(2)}'),
+            if (item.extra2Price != null)
+              pw.Text(
+                  '${item.extra2Desc ?? 'Additional 2'}: €${item.extra2Price!.toStringAsFixed(2)}'),
             pw.Text('Sectors: ${item.horizontalSections}x${item.verticalSections}'),
             pw.Text('Sashes: ${item.openings}'),
             pw.Text('Widths: ${item.sectionWidths.join(', ')}'),


### PR DESCRIPTION
## Summary
- show Additional 1/2 prices for items in the offer PDF when present

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792b663524832490705eb93624999d