### PR TITLE
Add last edited date and adjust PDF

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -256,6 +256,8 @@ class Offer extends HiveObject {
   double discountAmount;
   @HiveField(8)
   String notes;
+  @HiveField(9)
+  DateTime lastEdited;
   Offer({
     required this.id,
     required this.customerIndex,
@@ -266,5 +268,7 @@ class Offer extends HiveObject {
     this.discountPercent = 0,
     this.discountAmount = 0,
     this.notes = '',
-  }) : extraCharges = extraCharges ?? [];
+    DateTime? lastEdited,
+  })  : lastEdited = lastEdited ?? DateTime.now(),
+        extraCharges = extraCharges ?? [];
 }

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -406,13 +406,14 @@ class OfferAdapter extends TypeAdapter<Offer> {
       discountPercent: fields[6] as double,
       discountAmount: fields[7] as double,
       notes: fields[8] as String,
+      lastEdited: fields[9] as DateTime? ?? fields[2] as DateTime,
     );
   }
 
   @override
   void write(BinaryWriter writer, Offer obj) {
     writer
-      ..writeByte(9)
+      ..writeByte(10)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -430,7 +431,9 @@ class OfferAdapter extends TypeAdapter<Offer> {
       ..writeByte(7)
       ..write(obj.discountAmount)
       ..writeByte(8)
-      ..write(obj.notes);
+      ..write(obj.notes)
+      ..writeByte(9)
+      ..write(obj.lastEdited);
   }
 
   @override

--- a/lib/pages/offer_detail_page.dart
+++ b/lib/pages/offer_detail_page.dart
@@ -121,6 +121,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                               ElevatedButton(
                                 onPressed: () {
                                   offer.customerIndex = selected;
+                                  offer.lastEdited = DateTime.now();
                                   offer.save();
                                   setState(() {});
                                   Navigator.pop(context);
@@ -170,6 +171,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                             onPressed: () {
                               final val = double.tryParse(controller.text) ?? offer.profitPercent;
                               offer.profitPercent = val;
+                              offer.lastEdited = DateTime.now();
                               offer.save();
                               setState(() {});
                               Navigator.pop(context);
@@ -255,6 +257,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                         TextButton(
                           onPressed: () {
                             offer.items.removeAt(i);
+                            offer.lastEdited = DateTime.now();
                             offer.save();
                             setState(() {});
                             Navigator.pop(context);
@@ -271,6 +274,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                                   existingItem: item,
                                   onSave: (editedItem) {
                                     offer.items[i] = editedItem;
+                                    offer.lastEdited = DateTime.now();
                                     offer.save();
                                     setState(() {});
                                   },
@@ -371,6 +375,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                           const InputDecoration(labelText: 'Përshkrimi'),
                           onChanged: (v) {
                             charge.description = v;
+                            offer.lastEdited = DateTime.now();
                             offer.save();
                           },
                         ),
@@ -385,6 +390,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                           const InputDecoration(labelText: 'Sasia'),
                           onChanged: (v) {
                             charge.amount = double.tryParse(v) ?? 0;
+                            offer.lastEdited = DateTime.now();
                             offer.save();
                             setState(() {});
                           },
@@ -400,6 +406,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                           if (i < extraAmountControllers.length) {
                             extraAmountControllers.removeAt(i);
                           }
+                          offer.lastEdited = DateTime.now();
                           offer.save();
                           setState(() {});
                         },
@@ -414,6 +421,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                       offer.extraCharges.add(ExtraCharge());
                       extraDescControllers.add(TextEditingController());
                       extraAmountControllers.add(TextEditingController());
+                      offer.lastEdited = DateTime.now();
                       offer.save();
                       setState(() {});
                     },
@@ -427,6 +435,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                   decoration: const InputDecoration(labelText: 'Zbritja %'),
                   onChanged: (val) {
                     offer.discountPercent = double.tryParse(val) ?? 0;
+                    offer.lastEdited = DateTime.now();
                     offer.save();
                     setState(() {});
                   },
@@ -437,6 +446,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                   decoration: const InputDecoration(labelText: 'Zbritja'),
                   onChanged: (val) {
                     offer.discountAmount = double.tryParse(val) ?? 0;
+                    offer.lastEdited = DateTime.now();
                     offer.save();
                     setState(() {});
                   },
@@ -448,6 +458,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                   maxLines: 3,
                   onChanged: (val) {
                     offer.notes = val;
+                    offer.lastEdited = DateTime.now();
                     offer.save();
                   },
                 ),
@@ -465,6 +476,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
               builder: (_) => WindowDoorItemPage(
                 onSave: (item) {
                   offer.items.add(item);
+                  offer.lastEdited = DateTime.now();
                   offer.save();
                   setState(() {});
                 },

--- a/lib/pages/offers_page.dart
+++ b/lib/pages/offers_page.dart
@@ -71,6 +71,7 @@ class _OffersPageState extends State<OffersPage> {
                     id: DateTime.now().millisecondsSinceEpoch.toString(),
                     customerIndex: selectedCustomer,
                     date: DateTime.now(),
+                    lastEdited: DateTime.now(),
                     items: [],
                     profitPercent: double.tryParse(profitController.text) ?? 0,
                   ),

--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -100,6 +100,13 @@ Future<void> printOfferPdf({
   subtotal -= offer.discountAmount;
   final percentAmount = subtotal * (offer.discountPercent / 100);
   final finalTotal = subtotal - percentAmount;
+  String formattedFinalTotal = currency.format(finalTotal);
+  if (finalTotal >= 10000000) {
+    final parts = formattedFinalTotal.split('.');
+    if (parts.length == 2) {
+      formattedFinalTotal = '${parts[0]}.' '\n' '${parts[1]}';
+    }
+  }
 
   // ---- PHOTO CONTAINER SETTINGS ----
   final containerWidth = 150.0;
@@ -171,6 +178,8 @@ Future<void> printOfferPdf({
 
         final widgets = <pw.Widget>[];
         widgets.add(pw.Header(level: 0, child: pw.Text('Oferta $offerNumber', style: pw.TextStyle(fontSize: 18, fontWeight: pw.FontWeight.bold))));
+        widgets.add(pw.Text('Last edited: '
+            '${DateFormat('yyyy-MM-dd').format(offer.lastEdited)}'));
         widgets.add(pw.SizedBox(height: 12));
 
         final rows = <pw.TableRow>[];
@@ -354,7 +363,7 @@ Future<void> printOfferPdf({
             columnWidths: {
               0: pw.FixedColumnWidth(containerWidth + 40),
               1: pw.FixedColumnWidth(detailsWidth), // <--- set fixed width!
-              2: pw.FixedColumnWidth(70),
+              2: pw.FixedColumnWidth(100),
             },
             children: rows,
           ),
@@ -417,7 +426,8 @@ Future<void> printOfferPdf({
                 child: pw.Text('Totali', style: headerStyle)),
             pw.Padding(
                 padding: pw.EdgeInsets.all(4),
-                child: pw.Text(currency.format(finalTotal), style: headerStyle)),
+                child: pw.Text(formattedFinalTotal, style: headerStyle,
+                    textAlign: pw.TextAlign.right)),
           ]),
         );
 
@@ -427,7 +437,7 @@ Future<void> printOfferPdf({
             defaultVerticalAlignment: pw.TableCellVerticalAlignment.middle,
             columnWidths: {
               0: pw.FlexColumnWidth(),
-              1: pw.FixedColumnWidth(70),
+              1: pw.FixedColumnWidth(100),
             },
             children: summaryRows,
           ),


### PR DESCRIPTION
## Summary
- keep track of when an offer was edited
- show the last edited date in PDFs
- ensure wide price column and format long totals
- update pages to refresh last edited date when editing

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9c0ff1bc832489f3ba06f9ffb6a3