### PR TITLE
Add centralized color scheme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,8 @@ import 'pages/catalogs_page.dart';
 import 'pages/customers_page.dart';
 import 'pages/offers_page.dart';
 import 'pages/welcome_page.dart';
+import 'theme/app_colors.dart';
+import 'theme/app_theme.dart';
 
 
 void main() async {
@@ -39,10 +41,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'UPVC Helper',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
-        useMaterial3: true,
-      ),
+      theme: AppTheme.light,
       home: const WelcomePage(),
       routes: {
         '/home': (_) => const HomePage(),
@@ -55,11 +54,11 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.teal,
+      backgroundColor: AppColors.primary,
       appBar: AppBar(
         title: const Text('TONI AL-PVC',style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),),
         centerTitle: true,
-        backgroundColor: Colors.teal[800],
+        backgroundColor: AppColors.primaryDark,
       ),
       body: Padding(
         padding: const EdgeInsets.all(32),
@@ -112,7 +111,7 @@ class _MenuButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: Colors.teal[100],
+      color: AppColors.primaryLight,
       borderRadius: BorderRadius.circular(16),
       elevation: 4,
       child: InkWell(
@@ -123,9 +122,9 @@ class _MenuButton extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(icon, color: Colors.teal[800], size: 36),
+              Icon(icon, color: AppColors.primaryDark, size: 36),
               const SizedBox(width: 18),
-              Text(label, style: const TextStyle(fontSize: 20, color: Colors.teal, fontWeight: FontWeight.bold)),
+              Text(label, style: const TextStyle(fontSize: 20, color: AppColors.primary, fontWeight: FontWeight.bold)),
             ],
           ),
         ),

--- a/lib/pages/catalog_tab_page.dart
+++ b/lib/pages/catalog_tab_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../models.dart';
 import 'catalogs_page.dart';
+import '../theme/app_colors.dart';
 
 class CatalogTabPage extends StatefulWidget {
   final CatalogType type;
@@ -82,7 +83,7 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
               Navigator.pop(context);
               setState(() {});
             },
-            child: const Text('Delete', style: TextStyle(color: Colors.red)),
+            child: const Text('Delete', style: TextStyle(color: AppColors.delete)),
           ),
           TextButton(onPressed: () => Navigator.pop(context), child: const Text('Anulo')),
           ElevatedButton(

--- a/lib/pages/customers_page.dart
+++ b/lib/pages/customers_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../models.dart';
+import '../theme/app_colors.dart';
 
 class CustomersPage extends StatefulWidget {
   const CustomersPage({super.key});
@@ -86,7 +87,7 @@ class _CustomersPageState extends State<CustomersPage> {
               Navigator.pop(context);
               setState(() {});
             },
-            child: const Text('Fshij', style: TextStyle(color: Colors.red)),
+            child: const Text('Fshij', style: TextStyle(color: AppColors.delete)),
           ),
           TextButton(onPressed: () => Navigator.pop(context), child: const Text('Anulo')),
           ElevatedButton(

--- a/lib/pages/offer_detail_page.dart
+++ b/lib/pages/offer_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../models.dart';
 import 'window_door_item_page.dart';
+import '../theme/app_colors.dart';
 import 'dart:io' show File;
 import 'package:flutter/foundation.dart';
 import '../pdf/offer_pdf.dart';
@@ -266,7 +267,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                             setState(() {});
                             Navigator.pop(context);
                           },
-                          child: const Text("Fshij", style: TextStyle(color: Colors.red)),
+                          child: const Text("Fshij", style: TextStyle(color: AppColors.delete)),
                         ),
                         TextButton(
                           onPressed: () async {

--- a/lib/pages/offers_page.dart
+++ b/lib/pages/offers_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../models.dart';
 import 'offer_detail_page.dart';
+import '../theme/app_colors.dart';
 
 class OffersPage extends StatefulWidget {
   const OffersPage({super.key});
@@ -157,7 +158,7 @@ class _OffersPageState extends State<OffersPage> {
                               ),
                               TextButton(
                                 onPressed: () => Navigator.pop(context, true),
-                                child: const Text('Fshij', style: TextStyle(color: Colors.red)),
+                                child: const Text('Fshij', style: TextStyle(color: AppColors.delete)),
                               ),
                             ],
                           ),

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 class WelcomePage extends StatelessWidget {
   const WelcomePage({super.key});
@@ -9,7 +10,7 @@ class WelcomePage extends StatelessWidget {
       body: Container(
         decoration: const BoxDecoration(
           gradient: LinearGradient(
-            colors: [Colors.white, Colors.tealAccent],
+            colors: [Colors.white, AppColors.accent],
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
           ),

--- a/lib/pages/window_door_item_page.dart
+++ b/lib/pages/window_door_item_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'dart:io' show File;
 import 'dart:typed_data';
 import '../models.dart';
+import '../theme/app_colors.dart';
 
 
 class WindowDoorItemPage extends StatefulWidget {
@@ -131,7 +132,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                   : Container(
                 width: 120,
                 height: 120,
-                color: Colors.grey[300],
+                color: AppColors.grey300,
                 alignment: Alignment.center,
                 child: const Text('Kliko për të vendosë foton'),
               ),
@@ -534,8 +535,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                       child: Container(
                         margin: const EdgeInsets.all(4),
                         color: fixedSectors[r * verticalSections + c]
-                            ? Colors.grey[400]
-                            : Colors.lightGreen[300],
+                            ? AppColors.grey400
+                            : AppColors.lightGreen300,
                         child: Center(
                           child: Text(
                             fixedSectors[r * verticalSections + c]

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const MaterialColor primary = Colors.teal;
+  static Color get primaryDark => Colors.teal.shade800;
+  static Color get primaryLight => Colors.teal.shade100;
+  static const Color accent = Colors.tealAccent;
+  static Color get grey300 => Colors.grey.shade300;
+  static Color get grey400 => Colors.grey.shade400;
+  static Color get lightGreen300 => Colors.lightGreen.shade300;
+  static const Color delete = Colors.red;
+}

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+import 'app_colors.dart';
+
+class AppTheme {
+  static ThemeData get light => ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: AppColors.primary),
+        useMaterial3: true,
+      );
+}


### PR DESCRIPTION
## Summary
- centralize app colors in `AppColors`
- add a light theme in `AppTheme`
- update pages to use the new colors

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd16e38488324b2a7615d5fd108c0