### PR TITLE
Make app bar titles bold

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,7 +76,7 @@ class HomePage extends StatelessWidget {
                     'TONI AL-PVC',
                     style: TextStyle(
                       fontSize: 60,
-                      fontWeight: FontWeight.w900,
+                      fontWeight: FontWeight.bold,
                       color: AppColors.primary[500],
                       letterSpacing: 1.2,
                     ),

--- a/lib/pages/offers_page.dart
+++ b/lib/pages/offers_page.dart
@@ -184,7 +184,10 @@ class _OffersPageState extends State<OffersPage> {
                           }
                         },
                         child: ListTile(
-                          title: Text('Oferta ${i + 1}'),
+                          title: Text(
+                            'Oferta ${i + 1}',
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          ),
                           subtitle: Text(
                               'Klienti: ${customer?.name ?? "-"}\Data: ${offer?.date.toString().split(' ').first ?? "-"}'),
                         ),

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -16,6 +16,11 @@ class AppTheme {
       centerTitle: true,
       backgroundColor: AppColors.primary,
       foregroundColor: Colors.white,
+      titleTextStyle: TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.bold,
+        color: Colors.white,
+      ),
     ),
     cardTheme: CardThemeData(
       elevation: 3,


### PR DESCRIPTION
## Summary
- bold app bar titles using `titleTextStyle`
- emphasize offer titles in the Offers page
- use bold font weight for the main title

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff3a2aa5c8324a854855802c94d4c