### PR TITLE
Implement hidden image storage

### DIFF
--- a/lib/pages/window_door_item_page.dart
+++ b/lib/pages/window_door_item_page.dart
@@ -6,6 +6,7 @@ import 'dart:io' show File;
 import 'dart:typed_data';
 import '../models.dart';
 import '../theme/app_colors.dart';
+import '../utils/image_utils.dart';
 
 class WindowDoorItemPage extends StatefulWidget {
   final void Function(WindowDoorItem) onSave;
@@ -148,8 +149,16 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                                   source: ImageSource.gallery);
                               if (picked != null) {
                                 final bytes = await picked.readAsBytes();
+                                String? newPath;
+                                if (!kIsWeb) {
+                                  final ext = picked.path.split('.').last;
+                                  newPath = await saveImageToHiddenDir(
+                                      bytes,
+                                      fileName:
+                                          '${DateTime.now().millisecondsSinceEpoch}.$ext');
+                                }
                                 setState(() {
-                                  photoPath = picked.path;
+                                  photoPath = newPath;
                                   photoBytes = bytes;
                                 });
                               }

--- a/lib/utils/image_utils.dart
+++ b/lib/utils/image_utils.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Saves [bytes] as an image inside the application's documents directory
+/// under a folder that contains a `.nomedia` file so that the images remain
+/// hidden from the user's gallery on Android.
+///
+/// Returns the file path of the saved image or `null` on Web platforms.
+Future<String?> saveImageToHiddenDir(Uint8List bytes, {String? fileName}) async {
+  if (kIsWeb) return null;
+  final dir = await getApplicationDocumentsDirectory();
+  final imagesDir = Directory('${dir.path}/images');
+  if (!await imagesDir.exists()) {
+    await imagesDir.create(recursive: true);
+  }
+  final nomediaFile = File('${imagesDir.path}/.nomedia');
+  if (!await nomediaFile.exists()) {
+    await nomediaFile.create();
+  }
+  final name = fileName ?? '${DateTime.now().millisecondsSinceEpoch}.png';
+  final file = File('${imagesDir.path}/$name');
+  await file.writeAsBytes(bytes, flush: true);
+  return file.path;
+}


### PR DESCRIPTION
## Summary
- add image utility to save files in application storage with `.nomedia`
- update window item page to store selected photos using the new helper

## Testing
- ❌ `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688653f096e083248ce2a4ad66d00b22