### PR TITLE
Add PDF export templates and drag ordering

### DIFF
--- a/lib/pdf/pdf_template.dart
+++ b/lib/pdf/pdf_template.dart
@@ -1,0 +1,1 @@
+enum PdfTemplate { modern, classic }


### PR DESCRIPTION
## Summary
- support PDF template selection
- make optional summary page for PDF export
- allow drag-and-drop ordering of offer items
- fix summary widget scope for separate summary page
- precompute PDF summary to avoid undefined variable error

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889ba312f848324a6953a926402c161