### PR TITLE
Add template selection and item reordering

### DIFF
--- a/lib/pages/offer_detail_page.dart
+++ b/lib/pages/offer_detail_page.dart
@@ -67,6 +67,23 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
           IconButton(
             icon: const Icon(Icons.picture_as_pdf),
             onPressed: () async {
+              final template = await showDialog<PdfTemplate>(
+                context: context,
+                builder: (context) => SimpleDialog(
+                  title: const Text('Zgjidh Template'),
+                  children: [
+                    SimpleDialogOption(
+                      onPressed: () => Navigator.pop(context, PdfTemplate.modern),
+                      child: const Text('Modern'),
+                    ),
+                    SimpleDialogOption(
+                      onPressed: () => Navigator.pop(context, PdfTemplate.classic),
+                      child: const Text('Classic'),
+                    ),
+                  ],
+                ),
+              );
+              if (template == null) return;
               final offer = offerBox.getAt(widget.offerIndex)!;
               await printOfferPdf(
                 offer: offer,
@@ -77,6 +94,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                 blindBox: blindBox,
                 mechanismBox: mechanismBox,
                 accessoryBox: accessoryBox,
+                template: template,
               );
             },
           ),
@@ -196,135 +214,151 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
             ),
           ),
           const SizedBox(height: 8),
-          ...List.generate(offer.items.length, (i) {
-            final item = offer.items[i];
-            final profileSet = profileSetBox.getAt(item.profileSetIndex)!;
-            final glass = glassBox.getAt(item.glassIndex)!;
-            final blind = (item.blindIndex != null)
-                ? blindBox.getAt(item.blindIndex!)
-                : null;
-            final mechanism = (item.mechanismIndex != null)
-                ? mechanismBox.getAt(item.mechanismIndex!)
-                : null;
-            final accessory = (item.accessoryIndex != null)
-                ? accessoryBox.getAt(item.accessoryIndex!)
-                : null;
+          ReorderableListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: offer.items.length,
+            onReorder: (oldIndex, newIndex) {
+              setState(() {
+                if (newIndex > oldIndex) newIndex -= 1;
+                final item = offer.items.removeAt(oldIndex);
+                offer.items.insert(newIndex, item);
+                offer.lastEdited = DateTime.now();
+                offer.save();
+              });
+            },
+            itemBuilder: (context, i) {
+              final item = offer.items[i];
+              final profileSet = profileSetBox.getAt(item.profileSetIndex)!;
+              final glass = glassBox.getAt(item.glassIndex)!;
+              final blind = (item.blindIndex != null)
+                  ? blindBox.getAt(item.blindIndex!)
+                  : null;
+              final mechanism = (item.mechanismIndex != null)
+                  ? mechanismBox.getAt(item.mechanismIndex!)
+                  : null;
+              final accessory = (item.accessoryIndex != null)
+                  ? accessoryBox.getAt(item.accessoryIndex!)
+                  : null;
 
-            double profileCost = item.calculateProfileCost(profileSet,
-                    boxHeight: blind?.boxHeight ?? 0) *
-                item.quantity;
-            double glassCost = item.calculateGlassCost(glass,
-                    boxHeight: blind?.boxHeight ?? 0) *
-                item.quantity;
-            double blindCost = (blind != null)
-                ? ((item.width / 1000.0) *
-                    (item.height / 1000.0) *
-                    blind.pricePerM2 *
-                    item.quantity)
-                : 0;
-            double mechanismCost = (mechanism != null)
-                ? mechanism.price * item.quantity * item.openings
-                : 0;
-            double accessoryCost =
-                (accessory != null) ? accessory.price * item.quantity : 0;
-            double extras = (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
+              double profileCost = item.calculateProfileCost(profileSet,
+                      boxHeight: blind?.boxHeight ?? 0) *
+                  item.quantity;
+              double glassCost = item.calculateGlassCost(glass,
+                      boxHeight: blind?.boxHeight ?? 0) *
+                  item.quantity;
+              double blindCost = (blind != null)
+                  ? ((item.width / 1000.0) *
+                      (item.height / 1000.0) *
+                      blind.pricePerM2 *
+                      item.quantity)
+                  : 0;
+              double mechanismCost = (mechanism != null)
+                  ? mechanism.price * item.quantity * item.openings
+                  : 0;
+              double accessoryCost =
+                  (accessory != null) ? accessory.price * item.quantity : 0;
+              double extras = (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
 
-            double base = profileCost +
-                glassCost +
-                blindCost +
-                mechanismCost +
-                accessoryCost;
-            double total = base + extras;
-            double finalPrice;
-            if (item.manualPrice != null) {
-              finalPrice = item.manualPrice!;
-            } else {
-              finalPrice = base * (1 + offer.profitPercent / 100) + extras;
-            }
-            double profitAmount = finalPrice - total;
+              double base = profileCost +
+                  glassCost +
+                  blindCost +
+                  mechanismCost +
+                  accessoryCost;
+              double total = base + extras;
+              double finalPrice;
+              if (item.manualPrice != null) {
+                finalPrice = item.manualPrice!;
+              } else {
+                finalPrice = base * (1 + offer.profitPercent / 100) + extras;
+              }
+              double profitAmount = finalPrice - total;
 
-            return GlassCard(
-              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              onTap: () async {
-                await showDialog(
-                  context: context,
-                  builder: (_) => AlertDialog(
-                    title: const Text("Ndrysho/Fshij Dritaren/Derën"),
-                    content: const Text("A dëshironi ta fshini këtë?"),
-                    actions: [
-                      TextButton(
-                        onPressed: () {
-                          offer.items.removeAt(i);
-                          offer.lastEdited = DateTime.now();
-                          offer.save();
-                          setState(() {});
-                          Navigator.pop(context);
-                        },
-                        child: const Text("Fshij",
-                            style: TextStyle(color: AppColors.delete)),
-                      ),
-                      TextButton(
-                        onPressed: () async {
-                          Navigator.pop(context);
-                          await Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => WindowDoorItemPage(
-                                existingItem: item,
-                                onSave: (editedItem) {
-                                  offer.items[i] = editedItem;
-                                  offer.lastEdited = DateTime.now();
-                                  offer.save();
-                                  setState(() {});
-                                },
+              return GlassCard(
+                key: ValueKey(i),
+                margin:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                onTap: () async {
+                  await showDialog(
+                    context: context,
+                    builder: (_) => AlertDialog(
+                      title: const Text('Ndrysho/Fshij Dritaren/Derën'),
+                      content: const Text('A dëshironi ta fshini këtë?'),
+                      actions: [
+                        TextButton(
+                          onPressed: () {
+                            offer.items.removeAt(i);
+                            offer.lastEdited = DateTime.now();
+                            offer.save();
+                            setState(() {});
+                            Navigator.pop(context);
+                          },
+                          child: const Text('Fshij',
+                              style: TextStyle(color: AppColors.delete)),
+                        ),
+                        TextButton(
+                          onPressed: () async {
+                            Navigator.pop(context);
+                            await Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => WindowDoorItemPage(
+                                  existingItem: item,
+                                  onSave: (editedItem) {
+                                    offer.items[i] = editedItem;
+                                    offer.lastEdited = DateTime.now();
+                                    offer.save();
+                                    setState(() {});
+                                  },
+                                ),
                               ),
-                            ),
-                          );
-                        },
-                        child: const Text("Ndrysho"),
-                      ),
-                      TextButton(
-                        onPressed: () => Navigator.pop(context),
-                        child: const Text("Anulo"),
-                      ),
-                    ],
+                            );
+                          },
+                          child: const Text('Ndrysho'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(context),
+                          child: const Text('Anulo'),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+                child: ListTile(
+                  leading: item.photoPath != null
+                      ? (kIsWeb
+                          ? Image.network(item.photoPath!,
+                              width: 60, height: 60, fit: BoxFit.contain)
+                          : Image.file(File(item.photoPath!),
+                              width: 60, height: 60, fit: BoxFit.contain))
+                      : null,
+                  title: Text(item.name),
+                  subtitle: Text(
+                    'Madhësia: ${item.width} x ${item.height} mm\n'
+                    'Pcs: ${item.quantity}\n'
+                    'Profili: ${profileSet.name}\n'
+                    'Xhami: ${glass.name}\n'
+                    'Sektorët: ${item.horizontalSections}x${item.verticalSections}\n'
+                    'Krahët: ${item.openings}\n'
+                    'Gjerësitë: ${item.sectionWidths.join(', ')}\n'
+                    'Lartësitë: ${item.sectionHeights.join(', ')}\n'
+                    'V div: ${item.verticalAdapters.map((a) => a ? 'Adapter' : 'T').join(', ')}\n'
+                    'H div: ${item.horizontalAdapters.map((a) => a ? 'Adapter' : 'T').join(', ')}\n'
+                    'Kostoja e Profilit: €${profileCost.toStringAsFixed(2)}\n'
+                    'Kostoja e Xhamit: €${glassCost.toStringAsFixed(2)}\n'
+                    '${blind != null ? "Roleta: ${blind.name}, €${blindCost.toStringAsFixed(2)}\n" : ""}'
+                    '${mechanism != null ? "Mekanizmi: ${mechanism.name}, €${mechanismCost.toStringAsFixed(2)}\n" : ""}'
+                    '${accessory != null ? "Aksesori: ${accessory.name}, €${accessoryCost.toStringAsFixed(2)}\n" : ""}'
+                    '${item.extra1Price != null ? "${item.extra1Desc ?? 'Shtesa 1'}: €${item.extra1Price!.toStringAsFixed(2)}\n" : ""}'
+                    '${item.extra2Price != null ? "${item.extra2Desc ?? 'Shtesa 2'}: €${item.extra2Price!.toStringAsFixed(2)}\n" : ""}'
+                    'Kostoja (0%): €${total.toStringAsFixed(2)}\n'
+                    'Kostoja me Fitim: €${finalPrice.toStringAsFixed(2)}\n'
+                    'Fitimi: €${profitAmount.toStringAsFixed(2)}',
                   ),
-                );
-              },
-              child: ListTile(
-                leading: item.photoPath != null
-                    ? (kIsWeb
-                        ? Image.network(item.photoPath!,
-                            width: 60, height: 60, fit: BoxFit.contain)
-                        : Image.file(File(item.photoPath!),
-                            width: 60, height: 60, fit: BoxFit.contain))
-                    : null,
-                title: Text(item.name),
-                subtitle: Text(
-                  'Madhësia: ${item.width} x ${item.height} mm\n'
-                  'Pcs: ${item.quantity}\n'
-                  'Profili: ${profileSet.name}\n'
-                  'Xhami: ${glass.name}\n'
-                  'Sektorët: ${item.horizontalSections}x${item.verticalSections}\n'
-                  'Krahët: ${item.openings}\n'
-                  'Gjerësitë: ${item.sectionWidths.join(', ')}\n'
-                  'Lartësitë: ${item.sectionHeights.join(', ')}\n'
-                  'V div: ${item.verticalAdapters.map((a) => a ? 'Adapter' : 'T').join(', ')}\n'
-                  'H div: ${item.horizontalAdapters.map((a) => a ? 'Adapter' : 'T').join(', ')}\n'
-                  'Kostoja e Profilit: €${profileCost.toStringAsFixed(2)}\n'
-                  'Kostoja e Xhamit: €${glassCost.toStringAsFixed(2)}\n'
-                  '${blind != null ? "Roleta: ${blind.name}, €${blindCost.toStringAsFixed(2)}\n" : ""}'
-                  '${mechanism != null ? "Mekanizmi: ${mechanism.name}, €${mechanismCost.toStringAsFixed(2)}\n" : ""}'
-                  '${accessory != null ? "Aksesori: ${accessory.name}, €${accessoryCost.toStringAsFixed(2)}\n" : ""}'
-                  '${item.extra1Price != null ? "${item.extra1Desc ?? 'Shtesa 1'}: €${item.extra1Price!.toStringAsFixed(2)}\n" : ""}'
-                  '${item.extra2Price != null ? "${item.extra2Desc ?? 'Shtesa 2'}: €${item.extra2Price!.toStringAsFixed(2)}\n" : ""}'
-                  'Kostoja (0%): €${total.toStringAsFixed(2)}\n'
-                  'Kostoja me Fitim: €${finalPrice.toStringAsFixed(2)}\n'
-                  'Fitimi: €${profitAmount.toStringAsFixed(2)}',
                 ),
-              ),
-            ).animate().fadeIn(duration: 200.ms).slideY(begin: 0.3);
-          }),
+              ).animate().fadeIn(duration: 200.ms).slideY(begin: 0.3);
+            },
+          ),
           const SizedBox(height: 16),
           Center(
             child: Builder(builder: (_) {

--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -10,6 +10,8 @@ import 'package:printing/printing.dart';
 import '../models.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
+enum PdfTemplate { classic, modern }
+
 Future<void> printOfferPdf({
   required Offer offer,
   required int offerNumber,
@@ -19,6 +21,7 @@ Future<void> printOfferPdf({
   required Box<Blind> blindBox,
   required Box<Mechanism> mechanismBox,
   required Box<Accessory> accessoryBox,
+  PdfTemplate template = PdfTemplate.classic,
 }) async {
   final fontData = await rootBundle.load('assets/fonts/Montserrat-Regular.ttf');
   final boldFontData =
@@ -143,62 +146,88 @@ Future<void> printOfferPdf({
     pw.MultiPage(
       pageFormat: PdfPageFormat.a4,
       margin: pw.EdgeInsets.all(24),
-      header: (context) => context.pageNumber == 1
-          ? pw.Container(
-              padding: pw.EdgeInsets.all(8),
-              decoration: pw.BoxDecoration(color: PdfColors.blue100),
-              child: pw.Row(
-                crossAxisAlignment: pw.CrossAxisAlignment.start,
-                mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
-                children: [
-                  pw.Row(
+      header: (context) {
+        if (template == PdfTemplate.classic) {
+          return context.pageNumber == 1
+              ? pw.Container(
+                  padding: pw.EdgeInsets.all(8),
+                  decoration: pw.BoxDecoration(color: PdfColors.blue100),
+                  child: pw.Row(
                     crossAxisAlignment: pw.CrossAxisAlignment.start,
+                    mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
                     children: [
-                      if (logoImage != null)
-                        pw.Padding(
-                          padding: pw.EdgeInsets.only(right: 8),
-                          child: pw.Image(logoImage!, width: 48, height: 48),
-                        ),
-                      pw.Column(
+                      pw.Row(
                         crossAxisAlignment: pw.CrossAxisAlignment.start,
                         children: [
-                          pw.Text('Toni Al-Pvc',
-                              style: pw.TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: pw.FontWeight.bold,
-                                  color: PdfColors.blue800)),
-                          pw.Text(
-                              'Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000'),
-                          pw.Text('+38344357639 | +38344268300'),
-                          pw.Text('www.tonialpvc.com | tonialpvc@gmail.com'),
+                          if (logoImage != null)
+                            pw.Padding(
+                              padding: pw.EdgeInsets.only(right: 8),
+                              child:
+                                  pw.Image(logoImage!, width: 48, height: 48),
+                            ),
+                          pw.Column(
+                            crossAxisAlignment: pw.CrossAxisAlignment.start,
+                            children: [
+                              pw.Text('Toni Al-Pvc',
+                                  style: pw.TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: pw.FontWeight.bold,
+                                      color: PdfColors.blue800)),
+                              pw.Text(
+                                  'Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000'),
+                              pw.Text('+38344357639 | +38344268300'),
+                              pw.Text('www.tonialpvc.com | tonialpvc@gmail.com'),
+                            ],
+                          ),
                         ],
                       ),
+                      if (customer != null)
+                        pw.Column(
+                          crossAxisAlignment: pw.CrossAxisAlignment.start,
+                          children: [
+                            pw.Text('Klienti',
+                                style: pw.TextStyle(
+                                    fontWeight: pw.FontWeight.bold)),
+                            pw.Text(customer.name),
+                            pw.Text(customer.address),
+                            pw.Text(customer.phone),
+                            pw.Text(customer.email),
+                          ],
+                        ),
                     ],
                   ),
-                  if (customer != null)
-                    pw.Column(
-                      crossAxisAlignment: pw.CrossAxisAlignment.start,
-                      children: [
-                        pw.Text('Klienti',
-                            style:
-                                pw.TextStyle(fontWeight: pw.FontWeight.bold)),
-                        pw.Text(customer.name),
-                        pw.Text(customer.address),
-                        pw.Text(customer.phone),
-                        pw.Text(customer.email),
-                      ],
-                    ),
-                ],
+                )
+              : pw.SizedBox();
+        } else {
+          return pw.Container(
+            padding: pw.EdgeInsets.symmetric(vertical: 8),
+            child: pw.Row(
+              mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: pw.CrossAxisAlignment.center,
+              children: [
+                if (logoImage != null)
+                  pw.Image(logoImage!, width: 40, height: 40),
+                pw.Text('Oferta $offerNumber',
+                    style: pw.TextStyle(
+                        fontSize: 20,
+                        fontWeight: pw.FontWeight.bold,
+                        color: PdfColors.blue)),
+                pw.Text('Page ${context.pageNumber} / ${context.pagesCount}',
+                    style: pw.TextStyle(fontSize: 12))
+              ],
+            ),
+          );
+        }
+      },
+      footer: (context) => template == PdfTemplate.classic
+          ? pw.Align(
+              alignment: pw.Alignment.centerRight,
+              child: pw.Text(
+                'Page ${context.pageNumber} / ${context.pagesCount}',
+                style: pw.TextStyle(fontSize: 12),
               ),
             )
           : pw.SizedBox(),
-      footer: (context) => pw.Align(
-        alignment: pw.Alignment.centerRight,
-        child: pw.Text(
-          'Page ${context.pageNumber} / ${context.pagesCount}',
-          style: pw.TextStyle(fontSize: 12),
-        ),
-      ),
       build: (context) {
         final headerStyle = pw.TextStyle(fontWeight: pw.FontWeight.bold);
 


### PR DESCRIPTION
## Summary
- add `PdfTemplate` enum for classic/modern templates
- allow selecting export template before PDF generation
- support drag-and-drop ordering of items using `ReorderableListView`
- update PDF generation with modern header option

## Testing
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6889d0b15cb8832490aaa7e8fe4990fc