### PR TITLE
Add total item count to offers

### DIFF
--- a/lib/pages/offer_detail_page.dart
+++ b/lib/pages/offer_detail_page.dart
@@ -330,6 +330,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
             child: Builder(builder: (_) {
               double itemsBase = 0;
               double itemsFinal = 0;
+              int totalPcs = 0;
               for (var item in offer.items) {
                 final profileSet = profileSetBox.getAt(item.profileSetIndex)!;
                 final glass = glassBox.getAt(item.glassIndex)!;
@@ -375,6 +376,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                 }
                 itemsBase += total;
                 itemsFinal += finalPrice;
+                totalPcs += item.quantity;
               }
               double extrasTotal =
                   offer.extraCharges.fold(0, (p, e) => p + e.amount);
@@ -385,6 +387,8 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
               double finalTotal = subtotal - percentAmount;
               double profitTotal = finalTotal - baseTotal;
               String summary =
+                  'Totali i artikujve: $totalPcs pcs\n';
+              summary +=
                   'Totali pa Fitim (0%): €${baseTotal.toStringAsFixed(2)}\n';
               for (var charge in offer.extraCharges) {
                 summary +=

--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -76,6 +76,7 @@ Future<void> printOfferPdf({
 
   final currency = NumberFormat.currency(locale: 'en_US', symbol: '€');
   double itemsFinal = 0;
+  int totalPcs = 0;
   for (final item in offer.items) {
     final profile = profileSetBox.getAt(item.profileSetIndex)!;
     final glass = glassBox.getAt(item.glassIndex)!;
@@ -117,6 +118,7 @@ Future<void> printOfferPdf({
     }
 
     itemsFinal += price;
+    totalPcs += item.quantity;
   }
   final extrasTotal =
       offer.extraCharges.fold<double>(0.0, (p, e) => p + e.amount);
@@ -430,6 +432,16 @@ Future<void> printOfferPdf({
         widgets.add(pw.SizedBox(height: 12));
 
         final summaryRows = <pw.TableRow>[];
+        summaryRows.add(
+          pw.TableRow(children: [
+            pw.Padding(
+                padding: pw.EdgeInsets.all(4),
+                child: pw.Text('Totali i artikujve (pcs)')),
+            pw.Padding(
+                padding: pw.EdgeInsets.all(4),
+                child: pw.Text('$totalPcs', textAlign: pw.TextAlign.right)),
+          ]),
+        );
         summaryRows.add(
           pw.TableRow(children: [
             pw.Padding(


### PR DESCRIPTION
## Summary
- show total pieces for all items on offer detail page
- include total item count in generated offer PDF

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688c8dffa23c8324a268bcc09d6eb6a6