### PR TITLE
Multiply extras by quantity and add item notes

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -147,6 +147,8 @@ class WindowDoorItem extends HiveObject {
   List<bool> horizontalAdapters; // true = adapter, false = T profile
   @HiveField(23)
   Uint8List? photoBytes; // raw image bytes
+  @HiveField(24)
+  String? notes; // optional notes for this item
 
   WindowDoorItem({
     required this.name,
@@ -166,6 +168,7 @@ class WindowDoorItem extends HiveObject {
     this.extra2Price,
     this.extra1Desc,
     this.extra2Desc,
+    this.notes,
     this.verticalSections = 1,
     this.horizontalSections = 1,
     List<bool>? fixedSectors,

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -312,6 +312,7 @@ class WindowDoorItemAdapter extends TypeAdapter<WindowDoorItem> {
       openings: fields[9] as int,
       photoPath: fields[10] as String?,
       photoBytes: fields[23] as Uint8List?,
+      notes: fields[24] as String?,
       manualPrice: fields[11] as double?,
       extra1Price: fields[12] as double?,
       extra2Price: fields[13] as double?,
@@ -330,7 +331,7 @@ class WindowDoorItemAdapter extends TypeAdapter<WindowDoorItem> {
   @override
   void write(BinaryWriter writer, WindowDoorItem obj) {
     writer
-      ..writeByte(24)
+      ..writeByte(25)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
@@ -378,7 +379,9 @@ class WindowDoorItemAdapter extends TypeAdapter<WindowDoorItem> {
       ..writeByte(22)
       ..write(obj.horizontalAdapters)
       ..writeByte(23)
-      ..write(obj.photoBytes);
+      ..write(obj.photoBytes)
+      ..writeByte(24)
+      ..write(obj.notes);
   }
 
   @override

--- a/lib/pages/offer_detail_page.dart
+++ b/lib/pages/offer_detail_page.dart
@@ -227,7 +227,9 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                 : 0;
             double accessoryCost =
                 (accessory != null) ? accessory.price * item.quantity : 0;
-            double extras = (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
+            double extras =
+                ((item.extra1Price ?? 0) + (item.extra2Price ?? 0)) *
+                    item.quantity;
 
             double base = profileCost +
                 glassCost +
@@ -316,8 +318,9 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                   '${blind != null ? "Roleta: ${blind.name}, €${blindCost.toStringAsFixed(2)}\n" : ""}'
                   '${mechanism != null ? "Mekanizmi: ${mechanism.name}, €${mechanismCost.toStringAsFixed(2)}\n" : ""}'
                   '${accessory != null ? "Aksesori: ${accessory.name}, €${accessoryCost.toStringAsFixed(2)}\n" : ""}'
-                  '${item.extra1Price != null ? "${item.extra1Desc ?? 'Shtesa 1'}: €${item.extra1Price!.toStringAsFixed(2)}\n" : ""}'
-                  '${item.extra2Price != null ? "${item.extra2Desc ?? 'Shtesa 2'}: €${item.extra2Price!.toStringAsFixed(2)}\n" : ""}'
+                  '${item.extra1Price != null ? "${item.extra1Desc ?? 'Shtesa 1'}: €${(item.extra1Price! * item.quantity).toStringAsFixed(2)}\n" : ""}'
+                  '${item.extra2Price != null ? "${item.extra2Desc ?? 'Shtesa 2'}: €${(item.extra2Price! * item.quantity).toStringAsFixed(2)}\n" : ""}'
+                  '${item.notes != null && item.notes!.isNotEmpty ? "Shënime: ${item.notes!}\n" : ""}'
                   'Kostoja (0%): €${total.toStringAsFixed(2)}\n'
                   'Kostoja me Fitim: €${finalPrice.toStringAsFixed(2)}\n'
                   'Fitimi: €${profitAmount.toStringAsFixed(2)}',
@@ -361,7 +364,8 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                 double accessoryCost =
                     (accessory != null) ? accessory.price * item.quantity : 0;
                 double extras =
-                    (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
+                    ((item.extra1Price ?? 0) + (item.extra2Price ?? 0)) *
+                        item.quantity;
                 double base = profileCost +
                     glassCost +
                     blindCost +

--- a/lib/pages/window_door_item_page.dart
+++ b/lib/pages/window_door_item_page.dart
@@ -35,6 +35,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
   late TextEditingController extra2Controller;
   late TextEditingController extra1DescController;
   late TextEditingController extra2DescController;
+  late TextEditingController notesController;
 
   int profileSetIndex = 0;
   int glassIndex = 0;
@@ -48,6 +49,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
   double? extra2Price;
   String? extra1Desc;
   String? extra2Desc;
+  String? notes;
   int verticalSections = 1;
   int horizontalSections = 1;
   List<bool> fixedSectors = [false];
@@ -89,6 +91,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
         TextEditingController(text: widget.existingItem?.extra1Desc ?? '');
     extra2DescController =
         TextEditingController(text: widget.existingItem?.extra2Desc ?? '');
+    notesController =
+        TextEditingController(text: widget.existingItem?.notes ?? '');
 
     profileSetIndex = widget.existingItem?.profileSetIndex ?? 0;
     glassIndex = widget.existingItem?.glassIndex ?? 0;
@@ -102,6 +106,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
     extra2Price = widget.existingItem?.extra2Price;
     extra1Desc = widget.existingItem?.extra1Desc;
     extra2Desc = widget.existingItem?.extra2Desc;
+    notes = widget.existingItem?.notes;
     verticalSections = widget.existingItem?.verticalSections ?? 1;
     horizontalSections = widget.existingItem?.horizontalSections ?? 1;
     fixedSectors =
@@ -339,6 +344,13 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                           ],
                         ),
                         const SizedBox(height: 12),
+                        TextField(
+                          controller: notesController,
+                          decoration:
+                              const InputDecoration(labelText: 'Shënime'),
+                          maxLines: 2,
+                        ),
+                        const SizedBox(height: 12),
                         DropdownButtonFormField<int?>(
                           value: mechanismIndex,
                           decoration: const InputDecoration(
@@ -450,6 +462,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
         extra2Price: double.tryParse(extra2Controller.text),
         extra1Desc: extra1DescController.text,
         extra2Desc: extra2DescController.text,
+        notes: notesController.text,
       ),
     );
     return true;

--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -105,7 +105,9 @@ Future<void> printOfferPdf({
         mechanism != null ? mechanism.price * item.quantity * item.openings : 0;
     final accessoryCost =
         accessory != null ? accessory.price * item.quantity : 0;
-    final extras = (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
+          final extras =
+              ((item.extra1Price ?? 0) + (item.extra2Price ?? 0)) *
+                  item.quantity;
 
     final base =
         profileCost + glassCost + blindCost + mechanismCost + accessoryCost;
@@ -265,7 +267,9 @@ Future<void> printOfferPdf({
               : 0;
           final accessoryCost =
               accessory != null ? accessory.price * item.quantity : 0;
-          final extras = (item.extra1Price ?? 0) + (item.extra2Price ?? 0);
+          final extras =
+              ((item.extra1Price ?? 0) + (item.extra2Price ?? 0)) *
+                  item.quantity;
 
           final base = profileCost +
               glassCost +
@@ -300,10 +304,12 @@ Future<void> printOfferPdf({
               pw.Text('Aksesori: ${accessory.name} = €${accessory.price}'),
             if (item.extra1Price != null)
               pw.Text(
-                  '${item.extra1Desc ?? 'Ekstra 1'}: €${item.extra1Price!.toStringAsFixed(2)}'),
+                  '${item.extra1Desc ?? 'Ekstra 1'}: €${(item.extra1Price! * item.quantity).toStringAsFixed(2)}'),
             if (item.extra2Price != null)
               pw.Text(
-                  '${item.extra2Desc ?? 'Ekstra 2'}: €${item.extra2Price!.toStringAsFixed(2)}'),
+                  '${item.extra2Desc ?? 'Ekstra 2'}: €${(item.extra2Price! * item.quantity).toStringAsFixed(2)}'),
+            if (item.notes != null && item.notes!.isNotEmpty)
+              pw.Text('Shënime: ${item.notes}'),
             pw.Text(
                 'Sektorët: ${item.horizontalSections}x${item.verticalSections}'),
             pw.Text('Hapje: ${item.openings}'),


### PR DESCRIPTION
## Summary
- Multiply each item's extra prices by the quantity when computing totals and generating PDFs
- Allow entering and saving notes for each window/door item, including PDF output

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f236a62fc8324970cd8802e87f052