### PR TITLE
Add Hekri cutting calculator with profile offsets

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -37,6 +37,12 @@ class ProfileSet extends HiveObject {
   double priceLlajsne; // Glazing bead
   @HiveField(6)
   int pipeLength; // Standard pipe length in mm
+  @HiveField(7)
+  int hekriOffsetL; // Hekri length difference for L profile
+  @HiveField(8)
+  int hekriOffsetZ; // Hekri length difference for Z profile
+  @HiveField(9)
+  int hekriOffsetT; // Hekri length difference for T profile
 
   ProfileSet({
     required this.name,
@@ -46,6 +52,9 @@ class ProfileSet extends HiveObject {
     required this.priceAdapter,
     required this.priceLlajsne,
     this.pipeLength = 6500,
+    this.hekriOffsetL = 0,
+    this.hekriOffsetZ = 0,
+    this.hekriOffsetT = 0,
   });
 }
 

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -67,13 +67,16 @@ class ProfileSetAdapter extends TypeAdapter<ProfileSet> {
       priceAdapter: fields[4] as double,
       priceLlajsne: fields[5] as double,
       pipeLength: fields[6] as int,
+      hekriOffsetL: fields[7] as int? ?? 0,
+      hekriOffsetZ: fields[8] as int? ?? 0,
+      hekriOffsetT: fields[9] as int? ?? 0,
     );
   }
 
   @override
   void write(BinaryWriter writer, ProfileSet obj) {
     writer
-      ..writeByte(7)
+      ..writeByte(10)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
@@ -87,7 +90,13 @@ class ProfileSetAdapter extends TypeAdapter<ProfileSet> {
       ..writeByte(5)
       ..write(obj.priceLlajsne)
       ..writeByte(6)
-      ..write(obj.pipeLength);
+      ..write(obj.pipeLength)
+      ..writeByte(7)
+      ..write(obj.hekriOffsetL)
+      ..writeByte(8)
+      ..write(obj.hekriOffsetZ)
+      ..writeByte(9)
+      ..write(obj.hekriOffsetT);
   }
 
   @override

--- a/lib/pages/hekri_page.dart
+++ b/lib/pages/hekri_page.dart
@@ -1,16 +1,249 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import '../models.dart';
 import '../theme/app_background.dart';
+import '../widgets/glass_card.dart';
+import 'hekri_profiles_page.dart';
 
-class HekriPage extends StatelessWidget {
+class HekriPage extends StatefulWidget {
   const HekriPage({super.key});
+
+  @override
+  State<HekriPage> createState() => _HekriPageState();
+}
+
+enum PieceType { l, z, t }
+
+class _HekriPageState extends State<HekriPage> {
+  late Box<Offer> offerBox;
+  late Box<ProfileSet> profileBox;
+  int? selectedOffer;
+  Map<int, List<List<int>>>? results;
+
+  @override
+  void initState() {
+    super.initState();
+    offerBox = Hive.box<Offer>('offers');
+    profileBox = Hive.box<ProfileSet>('profileSets');
+    if (offerBox.isNotEmpty) selectedOffer = 0;
+  }
+
+  void _openProfiles() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const HekriProfilesPage()),
+    );
+  }
+
+  void _calculate() {
+    if (selectedOffer == null) return;
+    final offer = offerBox.getAt(selectedOffer!);
+    if (offer == null) return;
+
+    final piecesMap = <int, List<int>>{};
+
+    for (final item in offer.items) {
+      final profile = profileBox.getAt(item.profileSetIndex);
+      if (profile == null) continue;
+      final blind = item.blindIndex != null
+          ? Hive.box<Blind>('blinds').getAt(item.blindIndex!)
+          : null;
+      final itemPieces =
+          _pieceLengths(item, boxHeight: blind?.boxHeight ?? 0);
+
+      for (int q = 0; q < item.quantity; q++) {
+        final list =
+            piecesMap.putIfAbsent(item.profileSetIndex, () => <int>[]);
+        for (final len in itemPieces[PieceType.l]!) {
+          final hLen = max(0, len - profile.hekriOffsetL);
+          if (hLen > 0) list.add(hLen);
+        }
+        for (final len in itemPieces[PieceType.z]!) {
+          final hLen = max(0, len - profile.hekriOffsetZ);
+          if (hLen > 0) list.add(hLen);
+        }
+        for (final len in itemPieces[PieceType.t]!) {
+          final hLen = max(0, len - profile.hekriOffsetT);
+          if (hLen > 0) list.add(hLen);
+        }
+      }
+    }
+
+    final res = <int, List<List<int>>>{};
+    piecesMap.forEach((index, pieces) {
+      final pipeLength = profileBox.getAt(index)?.pipeLength ?? 6500;
+      if (pieces.isEmpty) return;
+      final bars = _packPieces(pieces, pipeLength);
+      res[index] = bars;
+    });
+
+    setState(() => results = res);
+  }
+
+  Map<PieceType, List<int>> _pieceLengths(WindowDoorItem item,
+      {int boxHeight = 0}) {
+    final map = {
+      PieceType.l: <int>[],
+      PieceType.z: <int>[],
+      PieceType.t: <int>[],
+    };
+
+    final effectiveHeight = (item.height - boxHeight).clamp(0, item.height);
+
+    map[PieceType.l]!
+        .addAll([effectiveHeight, effectiveHeight, item.width, item.width]);
+
+    for (int r = 0; r < item.horizontalSections; r++) {
+      for (int c = 0; c < item.verticalSections; c++) {
+        final w = item.sectionWidths[c];
+        int h = item.sectionHeights[r];
+        if (r == item.horizontalSections - 1) {
+          h = (h - boxHeight).clamp(0, h);
+        }
+        final idx = r * item.verticalSections + c;
+        if (!item.fixedSectors[idx]) {
+          final sashW = (w - 90).clamp(0, w);
+          final sashH = (h - 90).clamp(0, h);
+          map[PieceType.z]!.addAll([sashH, sashH, sashW, sashW]);
+        }
+      }
+    }
+
+    for (int i = 0; i < item.verticalSections - 1; i++) {
+      if (!item.verticalAdapters[i]) {
+        map[PieceType.t]!.add((effectiveHeight - 80).clamp(0, effectiveHeight));
+      }
+    }
+    for (int i = 0; i < item.horizontalSections - 1; i++) {
+      if (!item.horizontalAdapters[i]) {
+        map[PieceType.t]!.add((item.width - 80).clamp(0, item.width));
+      }
+    }
+    return map;
+  }
+
+  List<List<int>> _packPieces(List<int> pieces, int pipeLength) {
+    final remaining = List<int>.from(pieces);
+    final bars = <List<int>>[];
+    while (remaining.isNotEmpty) {
+      final combo = _bestSubset(remaining, pipeLength);
+      if (combo.isEmpty) {
+        bars.add([remaining.removeAt(0)]);
+        continue;
+      }
+      final bar = <int>[];
+      combo.sort((a, b) => b.compareTo(a));
+      for (final idx in combo) {
+        bar.add(remaining[idx]);
+      }
+      combo.sort();
+      for (final idx in combo.reversed) {
+        remaining.removeAt(idx);
+      }
+      bars.add(bar);
+    }
+    return bars;
+  }
+
+  List<int> _bestSubset(List<int> pieces, int capacity) {
+    final reachable = List<bool>.filled(capacity + 1, false);
+    final parent = List<int?>.filled(capacity + 1, null);
+    final used = List<int?>.filled(capacity + 1, null);
+    reachable[0] = true;
+    for (int i = 0; i < pieces.length; i++) {
+      final len = pieces[i];
+      for (int j = capacity; j >= len; j--) {
+        if (!reachable[j] && reachable[j - len]) {
+          reachable[j] = true;
+          parent[j] = j - len;
+          used[j] = i;
+        }
+      }
+    }
+    int best = capacity;
+    while (best > 0 && !reachable[best]) best--;
+    final result = <int>[];
+    int cur = best;
+    while (cur > 0) {
+      final idx = used[cur];
+      if (idx == null) break;
+      result.add(idx);
+      cur = parent[cur]!;
+    }
+    return result;
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Hekri')),
-      body: const AppBackground(
-        child: Center(
-          child: Text('Përmbajtja e hekurt këtu'),
+      appBar: AppBar(
+        title: const Text('Hekri'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: _openProfiles,
+          ),
+        ],
+      ),
+      body: AppBackground(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: DropdownButton<int?>(
+                    value: selectedOffer,
+                    items: [
+                      for (int i = 0; i < offerBox.length; i++)
+                        DropdownMenuItem(
+                          value: i,
+                          child: Text('Oferta ${i + 1}'),
+                        )
+                    ],
+                    onChanged: (val) => setState(() => selectedOffer = val),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                ElevatedButton(
+                  onPressed: _calculate,
+                  child: const Text('Llogarit'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (results != null)
+              ...results!.entries.map((e) {
+                final profile = profileBox.getAt(e.key);
+                final pipeLen = profile?.pipeLength ?? 6500;
+                final bars = e.value;
+                final needed =
+                    bars.expand((b) => b).fold<int>(0, (a, b) => a + b);
+                final totalLen = bars.length * pipeLen;
+                final loss = totalLen - needed;
+                return GlassCard(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(profile?.name ?? 'Profili'),
+                      const SizedBox(height: 8),
+                      Text(
+                          'Nevojiten ${(needed / 1000).toStringAsFixed(2)} m, '
+                          'Pipa: ${bars.length}, '
+                          'Humbje ${(loss / 1000).toStringAsFixed(2)} m'),
+                      for (int i = 0; i < bars.length; i++)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 2),
+                          child: Text('Lenda ${i + 1}: '
+                              '${bars[i].join(' + ')} = '
+                              '${bars[i].fold<int>(0, (a, b) => a + b)}/$pipeLen'),
+                        ),
+                    ],
+                  ),
+                );
+              }),
+          ],
         ),
       ),
     );

--- a/lib/pages/hekri_profiles_page.dart
+++ b/lib/pages/hekri_profiles_page.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import '../models.dart';
+import '../theme/app_background.dart';
+import '../widgets/glass_card.dart';
+
+class HekriProfilesPage extends StatefulWidget {
+  const HekriProfilesPage({super.key});
+
+  @override
+  State<HekriProfilesPage> createState() => _HekriProfilesPageState();
+}
+
+class _HekriProfilesPageState extends State<HekriProfilesPage> {
+  late Box<ProfileSet> profileBox;
+
+  @override
+  void initState() {
+    super.initState();
+    profileBox = Hive.box<ProfileSet>('profileSets');
+  }
+
+  void _editProfile(int index) {
+    final profile = profileBox.getAt(index);
+    if (profile == null) return;
+    final offsetLController =
+        TextEditingController(text: profile.hekriOffsetL.toString());
+    final offsetZController =
+        TextEditingController(text: profile.hekriOffsetZ.toString());
+    final offsetTController =
+        TextEditingController(text: profile.hekriOffsetT.toString());
+
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(profile.name),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: offsetLController,
+              keyboardType: TextInputType.number,
+              decoration:
+                  const InputDecoration(labelText: 'Zbritje nga L (mm)'),
+            ),
+            TextField(
+              controller: offsetZController,
+              keyboardType: TextInputType.number,
+              decoration:
+                  const InputDecoration(labelText: 'Zbritje nga Z (mm)'),
+            ),
+            TextField(
+              controller: offsetTController,
+              keyboardType: TextInputType.number,
+              decoration:
+                  const InputDecoration(labelText: 'Zbritje nga T (mm)'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Anulo')),
+          ElevatedButton(
+            onPressed: () {
+              profileBox.putAt(
+                index,
+                ProfileSet(
+                  name: profile.name,
+                  priceL: profile.priceL,
+                  priceZ: profile.priceZ,
+                  priceT: profile.priceT,
+                  priceAdapter: profile.priceAdapter,
+                  priceLlajsne: profile.priceLlajsne,
+                  pipeLength: profile.pipeLength,
+                  hekriOffsetL: int.tryParse(offsetLController.text) ?? 0,
+                  hekriOffsetZ: int.tryParse(offsetZController.text) ?? 0,
+                  hekriOffsetT: int.tryParse(offsetTController.text) ?? 0,
+                ),
+              );
+              Navigator.pop(context);
+              setState(() {});
+            },
+            child: const Text('Ruaj'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profili të Regjistruar')),
+      body: AppBackground(
+        child: ValueListenableBuilder(
+          valueListenable: profileBox.listenable(),
+          builder: (context, Box<ProfileSet> box, _) {
+            return ListView.builder(
+              itemCount: box.length,
+              itemBuilder: (context, index) {
+                final profile = box.getAt(index);
+                if (profile == null) return const SizedBox();
+                return GlassCard(
+                  onTap: () => _editProfile(index),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(profile.name,
+                          style: const TextStyle(fontWeight: FontWeight.bold)),
+                      const SizedBox(height: 4),
+                      Text(
+                          'L: ${profile.hekriOffsetL}mm, Z: ${profile.hekriOffsetZ}mm, T: ${profile.hekriOffsetT}mm'),
+                    ],
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add Hekri offset fields to profile sets
- Allow editing Hekri offsets for each profile
- Implement Hekri cutting page using selected offer and profile offsets

## Testing
- `dart format lib/models.dart lib/models.g.dart lib/pages/hekri_page.dart lib/pages/hekri_profiles_page.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688f65086b8c83249dc06b6e07adb4da