### PR TITLE
Preserve offer numbers after deletions

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -310,17 +310,21 @@ class Offer extends HiveObject {
   String notes;
   @HiveField(9)
   DateTime lastEdited;
+  @HiveField(10)
+  int offerNumber;
   Offer({
     required this.id,
     required this.customerIndex,
     required this.date,
     required this.items,
+    int? offerNumber,
     this.profitPercent = 0,
     List<ExtraCharge>? extraCharges,
     this.discountPercent = 0,
     this.discountAmount = 0,
     this.notes = '',
     DateTime? lastEdited,
-  })  : lastEdited = lastEdited ?? DateTime.now(),
+  })  : offerNumber = offerNumber ?? 0,
+        lastEdited = lastEdited ?? DateTime.now(),
         extraCharges = extraCharges ?? [];
 }

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -425,13 +425,14 @@ class OfferAdapter extends TypeAdapter<Offer> {
       discountAmount: fields[7] as double,
       notes: fields[8] as String,
       lastEdited: fields[9] as DateTime?,
+      offerNumber: fields[10] as int?,
     );
   }
 
   @override
   void write(BinaryWriter writer, Offer obj) {
     writer
-      ..writeByte(10)
+      ..writeByte(11)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -451,7 +452,9 @@ class OfferAdapter extends TypeAdapter<Offer> {
       ..writeByte(8)
       ..write(obj.notes)
       ..writeByte(9)
-      ..write(obj.lastEdited);
+      ..write(obj.lastEdited)
+      ..writeByte(10)
+      ..write(obj.offerNumber);
   }
 
   @override

--- a/lib/pages/cutting_optimizer_page.dart
+++ b/lib/pages/cutting_optimizer_page.dart
@@ -187,11 +187,14 @@ class _CuttingOptimizerPageState extends State<CuttingOptimizerPage> {
                   child: DropdownButton<int?>(
                     value: selectedOffer,
                     items: [for (int i = 0; i < offerBox.length; i++) i]
-                        .map((i) => DropdownMenuItem(
-                              value: i,
-                              child: Text('Oferta ${i + 1}'),
-                            ))
-                        .toList(),
+                        .map((i) {
+                          final offer = offerBox.getAt(i);
+                          final num = offer?.offerNumber ?? i + 1;
+                          return DropdownMenuItem(
+                            value: i,
+                            child: Text('Oferta $num'),
+                          );
+                        }).toList(),
                     onChanged: (val) => setState(() => selectedOffer = val),
                   ),
                 ),

--- a/lib/pages/hekri_page.dart
+++ b/lib/pages/hekri_page.dart
@@ -200,7 +200,8 @@ class _HekriPageState extends State<HekriPage> {
                       for (int i = 0; i < offerBox.length; i++)
                         DropdownMenuItem(
                           value: i,
-                          child: Text('Oferta ${i + 1}'),
+                          child: Text(
+                              'Oferta ${offerBox.getAt(i)?.offerNumber ?? i + 1}'),
                         )
                     ],
                     onChanged: (val) => setState(() => selectedOffer = val),

--- a/lib/pages/offer_detail_page.dart
+++ b/lib/pages/offer_detail_page.dart
@@ -62,7 +62,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
     Offer offer = offerBox.getAt(widget.offerIndex)!;
     return Scaffold(
       appBar: AppBar(
-        title: Text('Oferta ${widget.offerIndex + 1}'),
+        title: Text('Oferta ${offer.offerNumber}'),
         actions: [
           IconButton(
             icon: const Icon(Icons.picture_as_pdf),
@@ -70,7 +70,7 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
               final offer = offerBox.getAt(widget.offerIndex)!;
               await printOfferPdf(
                 offer: offer,
-                offerNumber: widget.offerIndex + 1,
+                offerNumber: offer.offerNumber,
                 customerBox: customerBox,
                 profileSetBox: profileSetBox,
                 glassBox: glassBox,

--- a/lib/pages/offers_page.dart
+++ b/lib/pages/offers_page.dart
@@ -106,6 +106,10 @@ class _OffersPageState extends State<OffersPage> {
                 child: const Text('Anulo')),
             ElevatedButton(
               onPressed: () {
+                int maxNumber = 0;
+                for (final o in offerBox.values) {
+                  if (o.offerNumber > maxNumber) maxNumber = o.offerNumber;
+                }
                 offerBox.add(
                   Offer(
                     id: DateTime.now().millisecondsSinceEpoch.toString(),
@@ -113,6 +117,7 @@ class _OffersPageState extends State<OffersPage> {
                     date: DateTime.now(),
                     lastEdited: DateTime.now(),
                     items: [],
+                    offerNumber: maxNumber + 1,
                     profitPercent: double.tryParse(profitController.text) ?? 0,
                   ),
                 );
@@ -156,7 +161,8 @@ class _OffersPageState extends State<OffersPage> {
                             offer.customerIndex < customerBox.length
                         ? customerBox.getAt(offer.customerIndex)
                         : null;
-                    final numStr = (i + 1).toString();
+                    final numStr =
+                        (offer?.offerNumber ?? (i + 1)).toString();
                     if (query.isEmpty ||
                         numStr.contains(query) ||
                         (customer != null &&
@@ -218,7 +224,7 @@ class _OffersPageState extends State<OffersPage> {
                         },
                         child: ListTile(
                           title: Text(
-                            'Oferta ${i + 1}',
+                            'Oferta ${offer?.offerNumber ?? i + 1}',
                             style: const TextStyle(fontWeight: FontWeight.bold),
                           ),
                           subtitle: Text(

--- a/lib/pages/roleta_page.dart
+++ b/lib/pages/roleta_page.dart
@@ -57,11 +57,14 @@ class _RoletaPageState extends State<RoletaPage> {
                   child: DropdownButton<int?>(
                     value: selectedOffer,
                     items: [for (int i = 0; i < offerBox.length; i++) i]
-                        .map((i) => DropdownMenuItem(
-                              value: i,
-                              child: Text('Oferta ${i + 1}'),
-                            ))
-                        .toList(),
+                        .map((i) {
+                          final offer = offerBox.getAt(i);
+                          final num = offer?.offerNumber ?? i + 1;
+                          return DropdownMenuItem(
+                            value: i,
+                            child: Text('Oferta $num'),
+                          );
+                        }).toList(),
                     onChanged: (val) => setState(() => selectedOffer = val),
                   ),
                 ),

--- a/lib/pages/xhami_page.dart
+++ b/lib/pages/xhami_page.dart
@@ -92,11 +92,14 @@ class _XhamiPageState extends State<XhamiPage> {
                   child: DropdownButton<int?>(
                     value: selectedOffer,
                     items: [for (int i = 0; i < offerBox.length; i++) i]
-                        .map((i) => DropdownMenuItem(
-                              value: i,
-                              child: Text('Oferta ${i + 1}'),
-                            ))
-                        .toList(),
+                        .map((i) {
+                          final offer = offerBox.getAt(i);
+                          final num = offer?.offerNumber ?? i + 1;
+                          return DropdownMenuItem(
+                            value: i,
+                            child: Text('Oferta $num'),
+                          );
+                        }).toList(),
                     onChanged: (val) => setState(() => selectedOffer = val),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- Add persistent `offerNumber` to Offer model so numbers don't shift after deletions
- Use stored offer numbers when creating, listing, searching, and printing offers
- Update dropdowns across pages to display the saved offer numbers

## Testing
- `dart analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_688f6d7b528083248ba4b3e18b751ca8