### PR TITLE
feat: add manual base price option

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -133,6 +133,8 @@ class WindowDoorItem extends HiveObject {
   String? photoPath; // path to a photo of this item
   @HiveField(11)
   double? manualPrice; // optional manual override for final price
+  @HiveField(25)
+  double? manualBasePrice; // optional manual override for base price (0% profit)
   @HiveField(12)
   double? extra1Price; // optional extra price 1
   @HiveField(13)
@@ -174,6 +176,7 @@ class WindowDoorItem extends HiveObject {
     this.photoPath,
     this.photoBytes,
     this.manualPrice,
+    this.manualBasePrice,
     this.extra1Price,
     this.extra2Price,
     this.extra1Desc,

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -322,6 +322,7 @@ class WindowDoorItemAdapter extends TypeAdapter<WindowDoorItem> {
       photoPath: fields[10] as String?,
       photoBytes: fields[23] as Uint8List?,
       manualPrice: fields[11] as double?,
+      manualBasePrice: fields[25] as double?,
       extra1Price: fields[12] as double?,
       extra2Price: fields[13] as double?,
       extra1Desc: fields[14] as String?,
@@ -340,7 +341,7 @@ class WindowDoorItemAdapter extends TypeAdapter<WindowDoorItem> {
   @override
   void write(BinaryWriter writer, WindowDoorItem obj) {
     writer
-      ..writeByte(25)
+      ..writeByte(26)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
@@ -365,6 +366,8 @@ class WindowDoorItemAdapter extends TypeAdapter<WindowDoorItem> {
       ..write(obj.photoPath)
       ..writeByte(11)
       ..write(obj.manualPrice)
+      ..writeByte(25)
+      ..write(obj.manualBasePrice)
       ..writeByte(12)
       ..write(obj.extra1Price)
       ..writeByte(13)

--- a/lib/pages/offer_detail_page.dart
+++ b/lib/pages/offer_detail_page.dart
@@ -236,6 +236,9 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                 blindCost +
                 mechanismCost +
                 accessoryCost;
+            if (item.manualBasePrice != null) {
+              base = item.manualBasePrice!;
+            }
             double total = base + extras;
             double finalPrice;
             if (item.manualPrice != null) {
@@ -371,6 +374,9 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                     blindCost +
                     mechanismCost +
                     accessoryCost;
+                if (item.manualBasePrice != null) {
+                  base = item.manualBasePrice!;
+                }
                 double total = base + extras;
                 double finalPrice;
                 if (item.manualPrice != null) {

--- a/lib/pages/window_door_item_page.dart
+++ b/lib/pages/window_door_item_page.dart
@@ -31,6 +31,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
   late TextEditingController verticalController;
   late TextEditingController horizontalController;
   late TextEditingController priceController;
+  late TextEditingController basePriceController;
   late TextEditingController extra1Controller;
   late TextEditingController extra2Controller;
   late TextEditingController extra1DescController;
@@ -45,6 +46,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
   String? photoPath;
   Uint8List? photoBytes;
   double? manualPrice;
+  double? manualBasePrice;
   double? extra1Price;
   double? extra2Price;
   String? extra1Desc;
@@ -83,6 +85,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
         text: widget.existingItem?.horizontalSections.toString() ?? '1');
     priceController = TextEditingController(
         text: widget.existingItem?.manualPrice?.toString() ?? '');
+    basePriceController = TextEditingController(
+        text: widget.existingItem?.manualBasePrice?.toString() ?? '');
     extra1Controller = TextEditingController(
         text: widget.existingItem?.extra1Price?.toString() ?? '');
     extra2Controller = TextEditingController(
@@ -102,6 +106,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
     photoPath = widget.existingItem?.photoPath;
     photoBytes = widget.existingItem?.photoBytes;
     manualPrice = widget.existingItem?.manualPrice;
+    manualBasePrice = widget.existingItem?.manualBasePrice;
     extra1Price = widget.existingItem?.extra1Price;
     extra2Price = widget.existingItem?.extra2Price;
     extra1Desc = widget.existingItem?.extra1Desc;
@@ -225,13 +230,19 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                                 const SizedBox(width: 12),
                                 Expanded(
                                   child: TextField(
-                                      controller: priceController,
+                                      controller: basePriceController,
                                       decoration: const InputDecoration(
-                                          labelText: 'Çmimi manual (Opsional)'),
+                                          labelText: 'Çmimi 0% (Opsional)'),
                                       keyboardType: TextInputType.number),
                                 ),
                               ],
                             ),
+                            const SizedBox(height: 12),
+                            TextField(
+                                controller: priceController,
+                                decoration: const InputDecoration(
+                                    labelText: 'Çmimi me fitim (Opsional)'),
+                                keyboardType: TextInputType.number),
                             const SizedBox(height: 12),
                             DropdownButtonFormField<int>(
                               value: profileSetIndex,
@@ -461,6 +472,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
     final quantity = int.tryParse(quantityController.text) ?? 1;
     final openings = fixedSectors.where((f) => !f).length;
     final mPrice = double.tryParse(priceController.text);
+    final mBasePrice = double.tryParse(basePriceController.text);
 
     if (name.isEmpty || width <= 0 || height <= 0) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -493,6 +505,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
         photoPath: photoPath,
         photoBytes: photoBytes,
         manualPrice: mPrice,
+        manualBasePrice: mBasePrice,
         extra1Price: double.tryParse(extra1Controller.text),
         extra2Price: double.tryParse(extra2Controller.text),
         extra1Desc: extra1DescController.text,

--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -108,8 +108,11 @@ Future<void> printOfferPdf({
     final extras =
         ((item.extra1Price ?? 0) + (item.extra2Price ?? 0)) * item.quantity;
 
-    final base =
+    double base =
         profileCost + glassCost + blindCost + mechanismCost + accessoryCost;
+    if (item.manualBasePrice != null) {
+      base = item.manualBasePrice!;
+    }
     final total = base + extras;
     double price;
     if (item.manualPrice != null) {
@@ -269,11 +272,14 @@ Future<void> printOfferPdf({
           final extras = ((item.extra1Price ?? 0) + (item.extra2Price ?? 0)) *
               item.quantity;
 
-          final base = profileCost +
+          double base = profileCost +
               glassCost +
               blindCost +
               mechanismCost +
               accessoryCost;
+          if (item.manualBasePrice != null) {
+            base = item.manualBasePrice!;
+          }
           final total = base + extras;
           double finalPrice;
           if (item.manualPrice != null) {


### PR DESCRIPTION
## Summary
- add `manualBasePrice` to `WindowDoorItem` for 0% manual pricing
- allow entering both base price and price with profit in the item editor
- apply manual base price in offer and PDF calculations

## Testing
- `dart format lib/models.dart lib/pages/window_door_item_page.dart lib/pages/offer_detail_page.dart lib/pdf/offer_pdf.dart lib/models.g.dart` *(fails: command not found)*
- `apt-get update` *(failed: repository is not signed)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890db89aaf483248bff95f52787ab47