### PR TITLE
Add per-row vertical divider controls

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -193,6 +193,8 @@ class WindowDoorItem extends HiveObject {
   Uint8List? photoBytes; // raw image bytes
   @HiveField(24)
   String? notes; // optional notes for this item
+  @HiveField(26)
+  List<bool> verticalDividers; // true if a row uses vertical dividers
 
   WindowDoorItem({
     required this.name,
@@ -221,6 +223,7 @@ class WindowDoorItem extends HiveObject {
     List<int>? sectionHeights,
     List<bool>? verticalAdapters,
     List<bool>? horizontalAdapters,
+    List<bool>? verticalDividers,
   })  : fixedSectors = fixedSectors ??
             List<bool>.filled(verticalSections * horizontalSections, false),
         sectionWidths = sectionWidths ?? List<int>.filled(verticalSections, 0),
@@ -231,7 +234,10 @@ class WindowDoorItem extends HiveObject {
                 verticalSections > 0 ? verticalSections - 1 : 0, false),
         horizontalAdapters = horizontalAdapters ??
             List<bool>.filled(
-                horizontalSections > 0 ? horizontalSections - 1 : 0, false);
+                horizontalSections > 0 ? horizontalSections - 1 : 0, false),
+        verticalDividers = verticalDividers ??
+            List<bool>.filled(
+                horizontalSections, verticalSections > 1);
 
   /// Returns the cost for profiles using the exact section sizes.
   /// If [boxHeight] is provided, it will be subtracted from the total height
@@ -251,8 +257,10 @@ class WindowDoorItem extends HiveObject {
     double glazingBeadLength = 0;
 
     for (int r = 0; r < horizontalSections; r++) {
-      for (int c = 0; c < verticalSections; c++) {
-        final w = sectionWidths[c].toDouble();
+      final cols = verticalDividers[r] ? verticalSections : 1;
+      for (int c = 0; c < cols; c++) {
+        final w =
+            verticalDividers[r] ? sectionWidths[c].toDouble() : width.toDouble();
         final h = effectiveHeights[r].toDouble();
         final idx = r * verticalSections + c;
         if (!fixedSectors[idx]) {
@@ -261,17 +269,25 @@ class WindowDoorItem extends HiveObject {
           sashLength += 2 * (sashW + sashH) / 1000.0 * set.priceZ;
           final beadW = (sashW - 90).clamp(0, sashW);
           final beadH = (sashH - 90).clamp(0, sashH);
-          glazingBeadLength += 2 * (beadW + beadH) / 1000.0 * set.priceLlajsne;
+          glazingBeadLength +=
+              2 * (beadW + beadH) / 1000.0 * set.priceLlajsne;
         } else {
           final beadW = (w - 90).clamp(0, w);
           final beadH = (h - 90).clamp(0, h);
-          glazingBeadLength += 2 * (beadW + beadH) / 1000.0 * set.priceLlajsne;
+          glazingBeadLength +=
+              2 * (beadW + beadH) / 1000.0 * set.priceLlajsne;
         }
       }
     }
 
     for (int i = 0; i < verticalSections - 1; i++) {
-      final len = (effectiveHeight - 80).clamp(0, effectiveHeight);
+      double len = 0;
+      for (int r = 0; r < horizontalSections; r++) {
+        if (verticalDividers[r]) {
+          final h = effectiveHeights[r].toDouble();
+          len += (h - 80).clamp(0, h);
+        }
+      }
       if (verticalAdapters[i]) {
         adapterLength += (len / 1000.0) * set.priceAdapter;
       } else {
@@ -303,8 +319,10 @@ class WindowDoorItem extends HiveObject {
     }
     double total = 0;
     for (int r = 0; r < horizontalSections; r++) {
-      for (int c = 0; c < verticalSections; c++) {
-        final w = sectionWidths[c].toDouble();
+      final cols = verticalDividers[r] ? verticalSections : 1;
+      for (int c = 0; c < cols; c++) {
+        final w =
+            verticalDividers[r] ? sectionWidths[c].toDouble() : width.toDouble();
         final h = effectiveHeights[r].toDouble();
         final idx = r * verticalSections + c;
         if (!fixedSectors[idx]) {
@@ -341,8 +359,10 @@ class WindowDoorItem extends HiveObject {
     double glazingBeadLength = 0;
 
     for (int r = 0; r < horizontalSections; r++) {
-      for (int c = 0; c < verticalSections; c++) {
-        final w = sectionWidths[c].toDouble();
+      final cols = verticalDividers[r] ? verticalSections : 1;
+      for (int c = 0; c < cols; c++) {
+        final w =
+            verticalDividers[r] ? sectionWidths[c].toDouble() : width.toDouble();
         final h = effectiveHeights[r].toDouble();
         final idx = r * verticalSections + c;
         if (!fixedSectors[idx]) {
@@ -363,7 +383,13 @@ class WindowDoorItem extends HiveObject {
     }
 
     for (int i = 0; i < verticalSections - 1; i++) {
-      final len = (effectiveHeight - 80).clamp(0, effectiveHeight);
+      double len = 0;
+      for (int r = 0; r < horizontalSections; r++) {
+        if (verticalDividers[r]) {
+          final h = effectiveHeights[r].toDouble();
+          len += (h - 80).clamp(0, h);
+        }
+      }
       if (verticalAdapters[i]) {
         adapterLength += (len / 1000.0) * set.massAdapter;
       } else {
@@ -395,8 +421,10 @@ class WindowDoorItem extends HiveObject {
     }
     double total = 0;
     for (int r = 0; r < horizontalSections; r++) {
-      for (int c = 0; c < verticalSections; c++) {
-        final w = sectionWidths[c].toDouble();
+      final cols = verticalDividers[r] ? verticalSections : 1;
+      for (int c = 0; c < cols; c++) {
+        final w =
+            verticalDividers[r] ? sectionWidths[c].toDouble() : width.toDouble();
         final h = effectiveHeights[r].toDouble();
         final idx = r * verticalSections + c;
         if (!fixedSectors[idx]) {

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -362,13 +362,14 @@ class WindowDoorItemAdapter extends TypeAdapter<WindowDoorItem> {
       sectionHeights: (fields[20] as List?)?.cast<int>(),
       verticalAdapters: (fields[21] as List?)?.cast<bool>(),
       horizontalAdapters: (fields[22] as List?)?.cast<bool>(),
+      verticalDividers: (fields[26] as List?)?.cast<bool>(),
     );
   }
 
   @override
   void write(BinaryWriter writer, WindowDoorItem obj) {
     writer
-      ..writeByte(26)
+      ..writeByte(27)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
@@ -420,7 +421,9 @@ class WindowDoorItemAdapter extends TypeAdapter<WindowDoorItem> {
       ..writeByte(23)
       ..write(obj.photoBytes)
       ..writeByte(24)
-      ..write(obj.notes);
+      ..write(obj.notes)
+      ..writeByte(26)
+      ..write(obj.verticalDividers);
   }
 
   @override

--- a/lib/pages/cutting_optimizer_page.dart
+++ b/lib/pages/cutting_optimizer_page.dart
@@ -88,8 +88,10 @@ class _CuttingOptimizerPageState extends State<CuttingOptimizerPage> {
         .addAll([effectiveHeight, effectiveHeight, item.width, item.width]);
 
     for (int r = 0; r < item.horizontalSections; r++) {
-      for (int c = 0; c < item.verticalSections; c++) {
-        final w = item.sectionWidths[c];
+      final cols = item.verticalDividers[r] ? item.verticalSections : 1;
+      for (int c = 0; c < cols; c++) {
+        final w =
+            item.verticalDividers[r] ? item.sectionWidths[c] : item.width;
         int h = item.sectionHeights[r];
         if (r == item.horizontalSections - 1) {
           h = (h - boxHeight).clamp(0, h);
@@ -112,7 +114,17 @@ class _CuttingOptimizerPageState extends State<CuttingOptimizerPage> {
 
     for (int i = 0; i < item.verticalSections - 1; i++) {
       final type = item.verticalAdapters[i] ? PieceType.adapter : PieceType.t;
-      map[type]!.add((effectiveHeight - 80).clamp(0, effectiveHeight));
+      int len = 0;
+      for (int r = 0; r < item.horizontalSections; r++) {
+        if (item.verticalDividers[r]) {
+          int h = item.sectionHeights[r];
+          if (r == item.horizontalSections - 1) {
+            h = (h - boxHeight).clamp(0, h);
+          }
+          len += (h - 80).clamp(0, h);
+        }
+      }
+      map[type]!.add(len);
     }
     for (int i = 0; i < item.horizontalSections - 1; i++) {
       final type = item.horizontalAdapters[i] ? PieceType.adapter : PieceType.t;

--- a/lib/pages/hekri_page.dart
+++ b/lib/pages/hekri_page.dart
@@ -93,8 +93,10 @@ class _HekriPageState extends State<HekriPage> {
         .addAll([effectiveHeight, effectiveHeight, item.width, item.width]);
 
     for (int r = 0; r < item.horizontalSections; r++) {
-      for (int c = 0; c < item.verticalSections; c++) {
-        final w = item.sectionWidths[c];
+      final cols = item.verticalDividers[r] ? item.verticalSections : 1;
+      for (int c = 0; c < cols; c++) {
+        final w =
+            item.verticalDividers[r] ? item.sectionWidths[c] : item.width;
         int h = item.sectionHeights[r];
         if (r == item.horizontalSections - 1) {
           h = (h - boxHeight).clamp(0, h);
@@ -110,7 +112,17 @@ class _HekriPageState extends State<HekriPage> {
 
     for (int i = 0; i < item.verticalSections - 1; i++) {
       if (!item.verticalAdapters[i]) {
-        map[PieceType.t]!.add((effectiveHeight - 80).clamp(0, effectiveHeight));
+        int len = 0;
+        for (int r = 0; r < item.horizontalSections; r++) {
+          if (item.verticalDividers[r]) {
+            int h = item.sectionHeights[r];
+            if (r == item.horizontalSections - 1) {
+              h = (h - boxHeight).clamp(0, h);
+            }
+            len += (h - 80).clamp(0, h);
+          }
+        }
+        map[PieceType.t]!.add(len);
       }
     }
     for (int i = 0; i < item.horizontalSections - 1; i++) {

--- a/lib/pages/window_door_item_page.dart
+++ b/lib/pages/window_door_item_page.dart
@@ -59,6 +59,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
   List<int> sectionHeights = [0];
   List<bool> verticalAdapters = [];
   List<bool> horizontalAdapters = [];
+  List<bool> verticalDividers = [];
   List<TextEditingController> sectionWidthCtrls = [];
   List<TextEditingController> sectionHeightCtrls = [];
 
@@ -122,6 +123,9 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
         List<bool>.from(widget.existingItem?.verticalAdapters ?? []);
     horizontalAdapters =
         List<bool>.from(widget.existingItem?.horizontalAdapters ?? []);
+    verticalDividers = List<bool>.from(
+        widget.existingItem?.verticalDividers ??
+            List<bool>.filled(horizontalSections, verticalSections > 1));
     _ensureGridSize();
   }
 
@@ -502,6 +506,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
         sectionHeights: sectionHeights,
         verticalAdapters: verticalAdapters,
         horizontalAdapters: horizontalAdapters,
+        verticalDividers: verticalDividers,
         photoPath: photoPath,
         photoBytes: photoBytes,
         manualPrice: mPrice,
@@ -639,6 +644,17 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
           horizontalAdapters.sublist(0, horizontalSections - 1);
     }
 
+    if (verticalDividers.length < horizontalSections) {
+      verticalDividers.addAll(List<bool>.filled(
+          horizontalSections - verticalDividers.length,
+          verticalSections > 1));
+    } else if (verticalDividers.length > horizontalSections) {
+      verticalDividers = verticalDividers.sublist(0, horizontalSections);
+    }
+    if (verticalSections <= 1) {
+      verticalDividers = List<bool>.filled(horizontalSections, false);
+    }
+
     _recalculateWidths();
     _recalculateHeights();
   }
@@ -755,9 +771,15 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                     ),
                   ),
                 ),
-                for (int c = 0; c < verticalSections; c++)
+                for (int c = 0;
+                    c < (verticalDividers[r] ? verticalSections : 1);
+                    c++)
                   Expanded(
-                    flex: sectionWidths[c] > 0 ? sectionWidths[c] : 1,
+                    flex: verticalDividers[r]
+                        ? (sectionWidths[c] > 0 ? sectionWidths[c] : 1)
+                        : (sectionWidths.fold(0, (a, b) => a + b) > 0
+                            ? sectionWidths.fold(0, (a, b) => a + b)
+                            : 1),
                     child: GestureDetector(
                       onTap: () {
                         int index = r * verticalSections + c;
@@ -832,6 +854,18 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
             onChanged: (val) =>
                 setState(() => verticalAdapters[i] = val ?? false),
           ),
+        if (verticalSections > 1 && horizontalSections > 0)
+          const SizedBox(height: 8),
+        if (verticalSections > 1 && horizontalSections > 0)
+          const Text('Divider për Seksionet Horizontale'),
+        if (verticalSections > 1)
+          for (int i = 0; i < horizontalSections; i++)
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text('H${i + 1}'),
+              value: verticalDividers[i],
+              onChanged: (val) => setState(() => verticalDividers[i] = val),
+            ),
         if (horizontalSections > 1) const SizedBox(height: 8),
         if (horizontalSections > 1) const Text('Ndarja Horizontale'),
         for (int i = 0; i < horizontalSections - 1; i++)

--- a/lib/pages/xhami_page.dart
+++ b/lib/pages/xhami_page.dart
@@ -58,8 +58,10 @@ class _XhamiPageState extends State<XhamiPage> {
     }
 
     for (int r = 0; r < item.horizontalSections; r++) {
-      for (int c = 0; c < item.verticalSections; c++) {
-        final w = item.sectionWidths[c];
+      final cols = item.verticalDividers[r] ? item.verticalSections : 1;
+      for (int c = 0; c < cols; c++) {
+        final w =
+            item.verticalDividers[r] ? item.sectionWidths[c] : item.width;
         final h = effectiveHeights[r];
         final idx = r * item.verticalSections + c;
         if (!item.fixedSectors[idx]) {


### PR DESCRIPTION
## Summary
- allow marking specific horizontal sections as undivided
- update glass and profile calculations to respect optional vertical dividers
- expose vertical divider switches in item editor

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891ae8dac58832492522248100ea602