### PR TITLE
feat: allow custom profile dimensions

### DIFF
--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -75,13 +75,19 @@ class ProfileSetAdapter extends TypeAdapter<ProfileSet> {
       massT: fields[12] as double,
       massAdapter: fields[13] as double,
       massLlajsne: fields[14] as double,
+      lInnerThickness: fields[15] as int? ?? 0,
+      zInnerThickness: fields[16] as int? ?? 0,
+      tInnerThickness: fields[17] as int? ?? 0,
+      fixedGlassTakeoff: fields[18] as int? ?? 0,
+      sashGlassTakeoff: fields[19] as int? ?? 0,
+      sashValue: fields[20] as int? ?? 0,
     );
   }
 
   @override
   void write(BinaryWriter writer, ProfileSet obj) {
     writer
-      ..writeByte(15)
+      ..writeByte(21)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
@@ -111,7 +117,19 @@ class ProfileSetAdapter extends TypeAdapter<ProfileSet> {
       ..writeByte(13)
       ..write(obj.massAdapter)
       ..writeByte(14)
-      ..write(obj.massLlajsne);
+      ..write(obj.massLlajsne)
+      ..writeByte(15)
+      ..write(obj.lInnerThickness)
+      ..writeByte(16)
+      ..write(obj.zInnerThickness)
+      ..writeByte(17)
+      ..write(obj.tInnerThickness)
+      ..writeByte(18)
+      ..write(obj.fixedGlassTakeoff)
+      ..writeByte(19)
+      ..write(obj.sashGlassTakeoff)
+      ..writeByte(20)
+      ..write(obj.sashValue);
   }
 
   @override

--- a/lib/pages/catalog_tab_page.dart
+++ b/lib/pages/catalog_tab_page.dart
@@ -65,6 +65,18 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
         text: item is ProfileSet ? item.massAdapter.toString() : "");
     final massLlajsneController = TextEditingController(
         text: item is ProfileSet ? item.massLlajsne.toString() : "");
+    final lInnerController = TextEditingController(
+        text: item is ProfileSet ? item.lInnerThickness.toString() : "");
+    final zInnerController = TextEditingController(
+        text: item is ProfileSet ? item.zInnerThickness.toString() : "");
+    final tInnerController = TextEditingController(
+        text: item is ProfileSet ? item.tInnerThickness.toString() : "");
+    final fixedGlassController = TextEditingController(
+        text: item is ProfileSet ? item.fixedGlassTakeoff.toString() : "");
+    final sashGlassController = TextEditingController(
+        text: item is ProfileSet ? item.sashGlassTakeoff.toString() : "");
+    final sashValueController = TextEditingController(
+        text: item is ProfileSet ? item.sashValue.toString() : "");
     final pricePerM2Controller = TextEditingController(
         text:
             (item is Glass || item is Blind) ? item.pricePerM2.toString() : "");
@@ -135,6 +147,30 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                     controller: massLlajsneController,
                     decoration:
                         const InputDecoration(labelText: 'Masa Llajsne kg/m')),
+                TextField(
+                    controller: lInnerController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e brendshme L (mm)')),
+                TextField(
+                    controller: zInnerController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e brendshme Z (mm)')),
+                TextField(
+                    controller: tInnerController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e brendshme T (mm)')),
+                TextField(
+                    controller: fixedGlassController,
+                    decoration: const InputDecoration(
+                        labelText: 'Humbja xhami fiks (mm)')),
+                TextField(
+                    controller: sashGlassController,
+                    decoration: const InputDecoration(
+                        labelText: 'Humbja xhami krah (mm)')),
+                TextField(
+                    controller: sashValueController,
+                    decoration: const InputDecoration(
+                        labelText: 'Vlera krah (+mm)')),
               ],
               if (widget.type == CatalogType.glass ||
                   widget.type == CatalogType.blind)
@@ -205,6 +241,18 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                             double.tryParse(massAdapterController.text) ?? 0,
                         massLlajsne:
                             double.tryParse(massLlajsneController.text) ?? 0,
+                        lInnerThickness:
+                            int.tryParse(lInnerController.text) ?? 0,
+                        zInnerThickness:
+                            int.tryParse(zInnerController.text) ?? 0,
+                        tInnerThickness:
+                            int.tryParse(tInnerController.text) ?? 0,
+                        fixedGlassTakeoff:
+                            int.tryParse(fixedGlassController.text) ?? 0,
+                        sashGlassTakeoff:
+                            int.tryParse(sashGlassController.text) ?? 0,
+                        sashValue:
+                            int.tryParse(sashValueController.text) ?? 0,
                       ));
                   break;
                 case CatalogType.glass:
@@ -272,6 +320,12 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
     final massTController = TextEditingController();
     final massAdapterController = TextEditingController();
     final massLlajsneController = TextEditingController();
+    final lInnerController = TextEditingController();
+    final zInnerController = TextEditingController();
+    final tInnerController = TextEditingController();
+    final fixedGlassController = TextEditingController();
+    final sashGlassController = TextEditingController();
+    final sashValueController = TextEditingController();
     final pricePerM2Controller = TextEditingController();
     final massPerM2Controller = TextEditingController();
     final boxHeightController = TextEditingController();
@@ -333,6 +387,30 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                     controller: massLlajsneController,
                     decoration:
                         const InputDecoration(labelText: 'Masa Llajsne kg/m')),
+                TextField(
+                    controller: lInnerController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e brendshme L (mm)')),
+                TextField(
+                    controller: zInnerController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e brendshme Z (mm)')),
+                TextField(
+                    controller: tInnerController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e brendshme T (mm)')),
+                TextField(
+                    controller: fixedGlassController,
+                    decoration: const InputDecoration(
+                        labelText: 'Humbja xhami fiks (mm)')),
+                TextField(
+                    controller: sashGlassController,
+                    decoration: const InputDecoration(
+                        labelText: 'Humbja xhami krah (mm)')),
+                TextField(
+                    controller: sashValueController,
+                    decoration: const InputDecoration(
+                        labelText: 'Vlera krah (+mm)')),
               ],
               if (widget.type == CatalogType.glass ||
                   widget.type == CatalogType.blind)
@@ -387,6 +465,18 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                     massAdapter: double.tryParse(massAdapterController.text) ?? 0,
                     massLlajsne:
                         double.tryParse(massLlajsneController.text) ?? 0,
+                    lInnerThickness:
+                        int.tryParse(lInnerController.text) ?? 0,
+                    zInnerThickness:
+                        int.tryParse(zInnerController.text) ?? 0,
+                    tInnerThickness:
+                        int.tryParse(tInnerController.text) ?? 0,
+                    fixedGlassTakeoff:
+                        int.tryParse(fixedGlassController.text) ?? 0,
+                    sashGlassTakeoff:
+                        int.tryParse(sashGlassController.text) ?? 0,
+                    sashValue:
+                        int.tryParse(sashValueController.text) ?? 0,
                   ));
                   break;
                 case CatalogType.glass:

--- a/lib/pages/hekri_page.dart
+++ b/lib/pages/hekri_page.dart
@@ -49,7 +49,8 @@ class _HekriPageState extends State<HekriPage> {
       final blind = item.blindIndex != null
           ? Hive.box<Blind>('blinds').getAt(item.blindIndex!)
           : null;
-      final itemPieces = _pieceLengths(item, boxHeight: blind?.boxHeight ?? 0);
+      final itemPieces =
+          _pieceLengths(item, profile, boxHeight: blind?.boxHeight ?? 0);
 
       for (int q = 0; q < item.quantity; q++) {
         final list = piecesMap.putIfAbsent(item.profileSetIndex, () => <int>[]);
@@ -79,7 +80,7 @@ class _HekriPageState extends State<HekriPage> {
     setState(() => results = res);
   }
 
-  Map<PieceType, List<int>> _pieceLengths(WindowDoorItem item,
+  Map<PieceType, List<int>> _pieceLengths(WindowDoorItem item, ProfileSet set,
       {int boxHeight = 0}) {
     final map = {
       PieceType.l: <int>[],
@@ -92,30 +93,36 @@ class _HekriPageState extends State<HekriPage> {
     map[PieceType.l]!
         .addAll([effectiveHeight, effectiveHeight, item.width, item.width]);
 
+    final l = set.lInnerThickness.toDouble();
+    final sashAdd = set.sashValue.toDouble();
+
     for (int r = 0; r < item.horizontalSections; r++) {
       for (int c = 0; c < item.verticalSections; c++) {
-        final w = item.sectionWidths[c];
-        int h = item.sectionHeights[r];
+        final w = item.sectionWidths[c].toDouble();
+        double h = item.sectionHeights[r].toDouble();
         if (r == item.horizontalSections - 1) {
           h = (h - boxHeight).clamp(0, h);
         }
         final idx = r * item.verticalSections + c;
         if (!item.fixedSectors[idx]) {
-          final sashW = (w - 90).clamp(0, w);
-          final sashH = (h - 90).clamp(0, h);
-          map[PieceType.z]!.addAll([sashH, sashH, sashW, sashW]);
+          final sashW = (w - 2 * l + sashAdd).clamp(0, w);
+          final sashH = (h - 2 * l + sashAdd).clamp(0, h);
+          map[PieceType.z]!
+              .addAll([sashH.round(), sashH.round(), sashW.round(), sashW.round()]);
         }
       }
     }
 
     for (int i = 0; i < item.verticalSections - 1; i++) {
       if (!item.verticalAdapters[i]) {
-        map[PieceType.t]!.add((effectiveHeight - 80).clamp(0, effectiveHeight));
+        final len = (effectiveHeight - 2 * l).clamp(0, effectiveHeight).round();
+        map[PieceType.t]!.add(len);
       }
     }
     for (int i = 0; i < item.horizontalSections - 1; i++) {
       if (!item.horizontalAdapters[i]) {
-        map[PieceType.t]!.add((item.width - 80).clamp(0, item.width));
+        final len = (item.width - 2 * l).clamp(0, item.width).round();
+        map[PieceType.t]!.add(len);
       }
     }
     return map;

--- a/lib/pages/hekri_profiles_page.dart
+++ b/lib/pages/hekri_profiles_page.dart
@@ -76,6 +76,17 @@ class _HekriProfilesPageState extends State<HekriProfilesPage> {
                   hekriOffsetL: int.tryParse(offsetLController.text) ?? 0,
                   hekriOffsetZ: int.tryParse(offsetZController.text) ?? 0,
                   hekriOffsetT: int.tryParse(offsetTController.text) ?? 0,
+                  massL: profile.massL,
+                  massZ: profile.massZ,
+                  massT: profile.massT,
+                  massAdapter: profile.massAdapter,
+                  massLlajsne: profile.massLlajsne,
+                  lInnerThickness: profile.lInnerThickness,
+                  zInnerThickness: profile.zInnerThickness,
+                  tInnerThickness: profile.tInnerThickness,
+                  fixedGlassTakeoff: profile.fixedGlassTakeoff,
+                  sashGlassTakeoff: profile.sashGlassTakeoff,
+                  sashValue: profile.sashValue,
                 ),
               );
               Navigator.pop(context);

--- a/lib/pages/offer_detail_page.dart
+++ b/lib/pages/offer_detail_page.dart
@@ -213,9 +213,10 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
             double profileCost = item.calculateProfileCost(profileSet,
                     boxHeight: blind?.boxHeight ?? 0) *
                 item.quantity;
-            double glassCost = item.calculateGlassCost(glass,
-                    boxHeight: blind?.boxHeight ?? 0) *
-                item.quantity;
+            double glassCost =
+                item.calculateGlassCost(profileSet, glass,
+                        boxHeight: blind?.boxHeight ?? 0) *
+                    item.quantity;
             double blindCost = (blind != null)
                 ? ((item.width / 1000.0) *
                     (item.height / 1000.0) *
@@ -234,9 +235,10 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
             double profileMass = item.calculateProfileMass(profileSet,
                     boxHeight: blind?.boxHeight ?? 0) *
                 item.quantity;
-            double glassMass = item.calculateGlassMass(glass,
-                    boxHeight: blind?.boxHeight ?? 0) *
-                item.quantity;
+            double glassMass =
+                item.calculateGlassMass(profileSet, glass,
+                        boxHeight: blind?.boxHeight ?? 0) *
+                    item.quantity;
             double blindMass = (blind != null)
                 ? ((item.width / 1000.0) *
                     (item.height / 1000.0) *
@@ -376,9 +378,10 @@ class _OfferDetailPageState extends State<OfferDetailPage> {
                 double profileCost = item.calculateProfileCost(profileSet,
                         boxHeight: blind?.boxHeight ?? 0) *
                     item.quantity;
-                double glassCost = item.calculateGlassCost(glass,
-                        boxHeight: blind?.boxHeight ?? 0) *
-                    item.quantity;
+                double glassCost =
+                    item.calculateGlassCost(profileSet, glass,
+                            boxHeight: blind?.boxHeight ?? 0) *
+                        item.quantity;
                 double blindCost = (blind != null)
                     ? ((item.width / 1000.0) *
                         (item.height / 1000.0) *

--- a/lib/pages/xhami_page.dart
+++ b/lib/pages/xhami_page.dart
@@ -16,6 +16,7 @@ class _XhamiPageState extends State<XhamiPage> {
   late Box<Offer> offerBox;
   late Box<Glass> glassBox;
   late Box<Blind> blindBox;
+  late Box<ProfileSet> profileBox;
   int? selectedOffer;
   Map<int, Map<String, int>>? results; // glassIndex -> size -> qty
 
@@ -25,6 +26,7 @@ class _XhamiPageState extends State<XhamiPage> {
     offerBox = Hive.box<Offer>('offers');
     glassBox = Hive.box<Glass>('glasses');
     blindBox = Hive.box<Blind>('blinds');
+    profileBox = Hive.box<ProfileSet>('profileSets');
     if (offerBox.isNotEmpty) selectedOffer = 0;
   }
 
@@ -38,7 +40,10 @@ class _XhamiPageState extends State<XhamiPage> {
     for (final item in offer.items) {
       final blind =
           item.blindIndex != null ? blindBox.getAt(item.blindIndex!) : null;
-      final sizes = _glassSizes(item, boxHeight: blind?.boxHeight ?? 0);
+      final profile = profileBox.getAt(item.profileSetIndex);
+      if (profile == null) continue;
+      final sizes =
+          _glassSizes(item, profile, boxHeight: blind?.boxHeight ?? 0);
       final target = res.putIfAbsent(item.glassIndex, () => {});
       for (final size in sizes) {
         final key = '${size[0]} x ${size[1]}';
@@ -49,7 +54,8 @@ class _XhamiPageState extends State<XhamiPage> {
     setState(() => results = res);
   }
 
-  List<List<int>> _glassSizes(WindowDoorItem item, {int boxHeight = 0}) {
+  List<List<int>> _glassSizes(WindowDoorItem item, ProfileSet set,
+      {int boxHeight = 0}) {
     final sizes = <List<int>>[];
     final effectiveHeights = List<int>.from(item.sectionHeights);
     if (effectiveHeights.isNotEmpty) {
@@ -59,19 +65,29 @@ class _XhamiPageState extends State<XhamiPage> {
 
     for (int r = 0; r < item.horizontalSections; r++) {
       for (int c = 0; c < item.verticalSections; c++) {
-        final w = item.sectionWidths[c];
-        final h = effectiveHeights[r];
+        final w = item.sectionWidths[c].toDouble();
+        final h = effectiveHeights[r].toDouble();
         final idx = r * item.verticalSections + c;
+        final l = set.lInnerThickness.toDouble();
+        final z = set.zInnerThickness.toDouble();
+        const melt = 6.0;
+        final sashAdd = set.sashValue.toDouble();
+        final fixedTakeoff = set.fixedGlassTakeoff.toDouble();
+        final sashTakeoff = set.sashGlassTakeoff.toDouble();
         if (!item.fixedSectors[idx]) {
-          final sashW = (w - 90).clamp(0, w);
-          final sashH = (h - 90).clamp(0, h);
-          final glassW = (sashW - 10).clamp(0, sashW);
-          final glassH = (sashH - 10).clamp(0, sashH);
-          sizes.add([glassW, glassH]);
+          final sashW = (w - 2 * l + sashAdd).clamp(0, w);
+          final sashH = (h - 2 * l + sashAdd).clamp(0, h);
+          final glassW =
+              (sashW - melt - 2 * z - sashTakeoff).clamp(0, sashW);
+          final glassH =
+              (sashH - melt - 2 * z - sashTakeoff).clamp(0, sashH);
+          sizes.add([glassW.round(), glassH.round()]);
         } else {
-          final glassW = (w - 100).clamp(0, w);
-          final glassH = (h - 100).clamp(0, h);
-          sizes.add([glassW, glassH]);
+          final glassW =
+              (w - 2 * l - fixedTakeoff).clamp(0, w);
+          final glassH =
+              (h - 2 * l - fixedTakeoff).clamp(0, h);
+          sizes.add([glassW.round(), glassH.round()]);
         }
       }
     }

--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -92,9 +92,9 @@ Future<void> printOfferPdf({
     final profileCost =
         item.calculateProfileCost(profile, boxHeight: blind?.boxHeight ?? 0) *
             item.quantity;
-    final glassCost =
-        item.calculateGlassCost(glass, boxHeight: blind?.boxHeight ?? 0) *
-            item.quantity;
+    final glassCost = item
+            .calculateGlassCost(profile, glass, boxHeight: blind?.boxHeight ?? 0) *
+        item.quantity;
     final blindCost = blind != null
         ? ((item.width / 1000.0) *
             (item.height / 1000.0) *
@@ -256,7 +256,8 @@ Future<void> printOfferPdf({
                   boxHeight: blind?.boxHeight ?? 0) *
               item.quantity;
           final glassCost =
-              item.calculateGlassCost(glass, boxHeight: blind?.boxHeight ?? 0) *
+              item.calculateGlassCost(profile, glass,
+                      boxHeight: blind?.boxHeight ?? 0) *
                   item.quantity;
           final blindCost = blind != null
               ? ((item.width / 1000.0) *
@@ -275,8 +276,9 @@ Future<void> printOfferPdf({
           final profileMass = item.calculateProfileMass(profile,
                   boxHeight: blind?.boxHeight ?? 0) *
               item.quantity;
-          final glassMass = item.calculateGlassMass(glass,
-                  boxHeight: blind?.boxHeight ?? 0) *
+          final glassMass = item
+                  .calculateGlassMass(profile, glass,
+                      boxHeight: blind?.boxHeight ?? 0) *
               item.quantity;
           final blindMass = blind != null
               ? ((item.width / 1000.0) *


### PR DESCRIPTION
## Summary
- add inner thickness and glass takeoff settings to `ProfileSet`
- use those settings to compute profile, sash, and glass sizes
- expose new fields in catalog pages and update cutting/glass utilities

## Testing
- `dart format lib/models.dart lib/models.g.dart lib/pages/catalog_tab_page.dart lib/pages/xhami_page.dart lib/pages/cutting_optimizer_page.dart lib/pages/hekri_page.dart lib/pages/offer_detail_page.dart lib/pdf/offer_pdf.dart` *(command failed: dart: not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892719783ec8324b2b4beba66b79f1c