### PR TITLE
Ensure offer summary table stays on one PDF page

### DIFF
--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -546,14 +546,16 @@ Future<void> printOfferPdf({
         );
 
         widgets.add(
-          pw.Table(
-            border: pw.TableBorder.all(width: 0.5),
-            defaultVerticalAlignment: pw.TableCellVerticalAlignment.middle,
-            columnWidths: {
-              0: pw.FlexColumnWidth(),
-              1: pw.FixedColumnWidth(100),
-            },
-            children: summaryRows,
+          pw.KeepTogether(
+            child: pw.Table(
+              border: pw.TableBorder.all(width: 0.5),
+              defaultVerticalAlignment: pw.TableCellVerticalAlignment.middle,
+              columnWidths: {
+                0: pw.FlexColumnWidth(),
+                1: pw.FixedColumnWidth(100),
+              },
+              children: summaryRows,
+            ),
           ),
         );
         if (offer.notes.isNotEmpty) {


### PR DESCRIPTION
## Summary
- Wrap the offer's final summary table in a `KeepTogether` widget so the table will move to the next page if it doesn't fit, preventing it from splitting across pages.

## Testing
- `dart format lib/pdf/offer_pdf.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898fc5b3d088324b7f61e9d06962a61