### PR TITLE
Add optional U-value calculations

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -66,6 +66,16 @@ class ProfileSet extends HiveObject {
   int sashGlassTakeoff; // Takeoff for sash glass
   @HiveField(20)
   int sashValue; // Value added for sash calculation
+  @HiveField(21)
+  double? uf; // Thermal transmittance of profiles
+  @HiveField(22)
+  int lOuterThickness; // Outer thickness of L profile
+  @HiveField(23)
+  int zOuterThickness; // Outer thickness of Z profile
+  @HiveField(24)
+  int tOuterThickness; // Outer thickness of T profile
+  @HiveField(25)
+  int adapterOuterThickness; // Outer thickness of Adapter
 
   ProfileSet({
     required this.name,
@@ -89,6 +99,11 @@ class ProfileSet extends HiveObject {
     this.fixedGlassTakeoff = 0,
     this.sashGlassTakeoff = 0,
     this.sashValue = 0,
+    this.uf,
+    this.lOuterThickness = 0,
+    this.zOuterThickness = 0,
+    this.tOuterThickness = 0,
+    this.adapterOuterThickness = 0,
   });
 }
 
@@ -100,10 +115,16 @@ class Glass extends HiveObject {
   double pricePerM2;
   @HiveField(2)
   double massPerM2;
+  @HiveField(3)
+  double? ug; // Thermal transmittance of glass
+  @HiveField(4)
+  double? psi; // Linear thermal transmittance of glass
   Glass({
     required this.name,
     required this.pricePerM2,
     this.massPerM2 = 0,
+    this.ug,
+    this.psi,
   });
 }
 
@@ -507,6 +528,89 @@ class WindowDoorItem extends HiveObject {
       }
     }
     return total;
+  }
+
+  /// Calculates Uw value for the window/door item. Returns null if any
+  /// required parameter is missing.
+  double? calculateUw(ProfileSet set, Glass glass, {int boxHeight = 0}) {
+    final uf = set.uf;
+    final ug = glass.ug;
+    final psi = glass.psi;
+    if (uf == null || ug == null || psi == null) return null;
+
+    final effectiveHeight = (height - boxHeight).clamp(0, height);
+    final effectiveHeights = List<int>.from(sectionHeights);
+    if (effectiveHeights.isNotEmpty) {
+      effectiveHeights[effectiveHeights.length - 1] =
+          (effectiveHeights.last - boxHeight).clamp(0, effectiveHeights.last);
+    }
+    final l = set.lInnerThickness.toDouble();
+    final z = set.zInnerThickness.toDouble();
+    const melt = 6.0;
+    final sashAdd = set.sashValue.toDouble();
+    final fixedTakeoff = set.fixedGlassTakeoff.toDouble();
+    final sashTakeoff = set.sashGlassTakeoff.toDouble();
+
+    double frameLen = 2 * (width + effectiveHeight) / 1000.0;
+    double sashLen = 0;
+    double adapterLen = 0;
+    double tLen = 0;
+    double ag = 0;
+    double lg = 0;
+
+    for (int r = 0; r < horizontalSections; r++) {
+      for (int c = 0; c < verticalSections; c++) {
+        final w = sectionWidths[c].toDouble();
+        final h = effectiveHeights[r].toDouble();
+        final idx = r * verticalSections + c;
+        final insets = sectionInsets(set, r, c);
+        double glassW;
+        double glassH;
+        if (!fixedSectors[idx]) {
+          final sashW =
+              (w - insets.left - insets.right + sashAdd).clamp(0, w);
+          final sashH =
+              (h - insets.top - insets.bottom + sashAdd).clamp(0, h);
+          sashLen += 2 * (sashW + sashH) / 1000.0;
+          glassW = (sashW - melt - 2 * z - sashTakeoff).clamp(0, sashW);
+          glassH = (sashH - melt - 2 * z - sashTakeoff).clamp(0, sashH);
+        } else {
+          glassW =
+              (w - insets.left - insets.right - fixedTakeoff).clamp(0, w);
+          glassH =
+              (h - insets.top - insets.bottom - fixedTakeoff).clamp(0, h);
+        }
+        ag += (glassW / 1000.0) * (glassH / 1000.0);
+        lg += 2 * ((glassW + glassH) / 1000.0);
+      }
+    }
+
+    for (int i = 0; i < verticalSections - 1; i++) {
+      final len = (effectiveHeight - 2 * l).clamp(0, effectiveHeight) / 1000.0;
+      if (verticalAdapters[i]) {
+        adapterLen += len;
+      } else {
+        tLen += len;
+      }
+    }
+    for (int i = 0; i < horizontalSections - 1; i++) {
+      final len = (width - 2 * l).clamp(0, width) / 1000.0;
+      if (horizontalAdapters[i]) {
+        adapterLen += len;
+      } else {
+        tLen += len;
+      }
+    }
+
+    final af =
+        frameLen * (set.lOuterThickness / 1000.0) +
+            sashLen * (set.zOuterThickness / 1000.0) +
+            adapterLen * (set.adapterOuterThickness / 1000.0) +
+            tLen * (set.tOuterThickness / 1000.0);
+
+    final denom = ag + af;
+    if (denom == 0) return null;
+    return (af * uf + ag * ug + lg * psi) / denom;
   }
 }
 

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -81,13 +81,18 @@ class ProfileSetAdapter extends TypeAdapter<ProfileSet> {
       fixedGlassTakeoff: fields[18] as int? ?? 0,
       sashGlassTakeoff: fields[19] as int? ?? 0,
       sashValue: fields[20] as int? ?? 0,
+      uf: fields[21] as double?,
+      lOuterThickness: fields[22] as int? ?? 0,
+      zOuterThickness: fields[23] as int? ?? 0,
+      tOuterThickness: fields[24] as int? ?? 0,
+      adapterOuterThickness: fields[25] as int? ?? 0,
     );
   }
 
   @override
   void write(BinaryWriter writer, ProfileSet obj) {
     writer
-      ..writeByte(21)
+      ..writeByte(26)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
@@ -129,7 +134,17 @@ class ProfileSetAdapter extends TypeAdapter<ProfileSet> {
       ..writeByte(19)
       ..write(obj.sashGlassTakeoff)
       ..writeByte(20)
-      ..write(obj.sashValue);
+      ..write(obj.sashValue)
+      ..writeByte(21)
+      ..write(obj.uf)
+      ..writeByte(22)
+      ..write(obj.lOuterThickness)
+      ..writeByte(23)
+      ..write(obj.zOuterThickness)
+      ..writeByte(24)
+      ..write(obj.tOuterThickness)
+      ..writeByte(25)
+      ..write(obj.adapterOuterThickness);
   }
 
   @override
@@ -157,19 +172,25 @@ class GlassAdapter extends TypeAdapter<Glass> {
       name: fields[0] as String,
       pricePerM2: fields[1] as double,
       massPerM2: fields[2] as double,
+      ug: fields[3] as double?,
+      psi: fields[4] as double?,
     );
   }
 
   @override
   void write(BinaryWriter writer, Glass obj) {
     writer
-      ..writeByte(3)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
       ..write(obj.pricePerM2)
       ..writeByte(2)
-      ..write(obj.massPerM2);
+      ..write(obj.massPerM2)
+      ..writeByte(3)
+      ..write(obj.ug)
+      ..writeByte(4)
+      ..write(obj.psi);
   }
 
   @override

--- a/lib/pages/catalog_tab_page.dart
+++ b/lib/pages/catalog_tab_page.dart
@@ -71,6 +71,16 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
         text: item is ProfileSet ? item.zInnerThickness.toString() : "");
     final tInnerController = TextEditingController(
         text: item is ProfileSet ? item.tInnerThickness.toString() : "");
+    final ufController = TextEditingController(
+        text: item is ProfileSet ? (item.uf?.toString() ?? '') : '');
+    final lOuterController = TextEditingController(
+        text: item is ProfileSet ? item.lOuterThickness.toString() : "");
+    final zOuterController = TextEditingController(
+        text: item is ProfileSet ? item.zOuterThickness.toString() : "");
+    final tOuterController = TextEditingController(
+        text: item is ProfileSet ? item.tOuterThickness.toString() : "");
+    final adapterOuterController = TextEditingController(
+        text: item is ProfileSet ? item.adapterOuterThickness.toString() : "");
     final fixedGlassController = TextEditingController(
         text: item is ProfileSet ? item.fixedGlassTakeoff.toString() : "");
     final sashGlassController = TextEditingController(
@@ -83,6 +93,10 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
     final massPerM2Controller = TextEditingController(
         text:
             (item is Glass || item is Blind) ? item.massPerM2.toString() : "");
+    final ugController = TextEditingController(
+        text: item is Glass ? (item.ug?.toString() ?? '') : '');
+    final psiController = TextEditingController(
+        text: item is Glass ? (item.psi?.toString() ?? '') : '');
     final boxHeightController = TextEditingController(
         text: item is Blind ? item.boxHeight.toString() : "");
     final priceController = TextEditingController(
@@ -160,6 +174,26 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                     decoration: const InputDecoration(
                         labelText: 'Trashësia e brendshme T (mm)')),
                 TextField(
+                    controller: lOuterController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e jashtme L (mm)')),
+                TextField(
+                    controller: zOuterController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e jashtme Z (mm)')),
+                TextField(
+                    controller: tOuterController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e jashtme T (mm)')),
+                TextField(
+                    controller: adapterOuterController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e jashtme Adapter (mm)')),
+                TextField(
+                    controller: ufController,
+                    decoration:
+                        const InputDecoration(labelText: 'Uf (W/m²K)')),
+                TextField(
                     controller: fixedGlassController,
                     decoration: const InputDecoration(
                         labelText: 'Humbja xhami fiks (mm)')),
@@ -182,6 +216,16 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                 TextField(
                     controller: massPerM2Controller,
                     decoration: const InputDecoration(labelText: 'Masa kg/m²')),
+              if (widget.type == CatalogType.glass)
+                TextField(
+                    controller: ugController,
+                    decoration:
+                        const InputDecoration(labelText: 'Ug (W/m²K)')),
+              if (widget.type == CatalogType.glass)
+                TextField(
+                    controller: psiController,
+                    decoration:
+                        const InputDecoration(labelText: 'Psi (W/mK)')),
               if (widget.type == CatalogType.blind)
                 TextField(
                     controller: boxHeightController,
@@ -247,6 +291,15 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                             int.tryParse(zInnerController.text) ?? 0,
                         tInnerThickness:
                             int.tryParse(tInnerController.text) ?? 0,
+                        lOuterThickness:
+                            int.tryParse(lOuterController.text) ?? 0,
+                        zOuterThickness:
+                            int.tryParse(zOuterController.text) ?? 0,
+                        tOuterThickness:
+                            int.tryParse(tOuterController.text) ?? 0,
+                        adapterOuterThickness:
+                            int.tryParse(adapterOuterController.text) ?? 0,
+                        uf: double.tryParse(ufController.text),
                         fixedGlassTakeoff:
                             int.tryParse(fixedGlassController.text) ?? 0,
                         sashGlassTakeoff:
@@ -264,6 +317,8 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                             double.tryParse(pricePerM2Controller.text) ?? 0,
                         massPerM2:
                             double.tryParse(massPerM2Controller.text) ?? 0,
+                        ug: double.tryParse(ugController.text),
+                        psi: double.tryParse(psiController.text),
                       ));
                   break;
                 case CatalogType.blind:
@@ -323,11 +378,18 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
     final lInnerController = TextEditingController();
     final zInnerController = TextEditingController();
     final tInnerController = TextEditingController();
+    final ufController = TextEditingController();
+    final lOuterController = TextEditingController();
+    final zOuterController = TextEditingController();
+    final tOuterController = TextEditingController();
+    final adapterOuterController = TextEditingController();
     final fixedGlassController = TextEditingController();
     final sashGlassController = TextEditingController();
     final sashValueController = TextEditingController();
     final pricePerM2Controller = TextEditingController();
     final massPerM2Controller = TextEditingController();
+    final ugController = TextEditingController();
+    final psiController = TextEditingController();
     final boxHeightController = TextEditingController();
     final priceController = TextEditingController();
     final massController = TextEditingController();
@@ -400,6 +462,26 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                     decoration: const InputDecoration(
                         labelText: 'Trashësia e brendshme T (mm)')),
                 TextField(
+                    controller: lOuterController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e jashtme L (mm)')),
+                TextField(
+                    controller: zOuterController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e jashtme Z (mm)')),
+                TextField(
+                    controller: tOuterController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e jashtme T (mm)')),
+                TextField(
+                    controller: adapterOuterController,
+                    decoration: const InputDecoration(
+                        labelText: 'Trashësia e jashtme Adapter (mm)')),
+                TextField(
+                    controller: ufController,
+                    decoration:
+                        const InputDecoration(labelText: 'Uf (W/m²K)')),
+                TextField(
                     controller: fixedGlassController,
                     decoration: const InputDecoration(
                         labelText: 'Humbja xhami fiks (mm)')),
@@ -422,6 +504,16 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                 TextField(
                     controller: massPerM2Controller,
                     decoration: const InputDecoration(labelText: 'Masa kg/m²')),
+              if (widget.type == CatalogType.glass)
+                TextField(
+                    controller: ugController,
+                    decoration:
+                        const InputDecoration(labelText: 'Ug (W/m²K)')),
+              if (widget.type == CatalogType.glass)
+                TextField(
+                    controller: psiController,
+                    decoration:
+                        const InputDecoration(labelText: 'Psi (W/mK)')),
               if (widget.type == CatalogType.blind)
                 TextField(
                     controller: boxHeightController,
@@ -471,6 +563,15 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                         int.tryParse(zInnerController.text) ?? 0,
                     tInnerThickness:
                         int.tryParse(tInnerController.text) ?? 0,
+                    lOuterThickness:
+                        int.tryParse(lOuterController.text) ?? 0,
+                    zOuterThickness:
+                        int.tryParse(zOuterController.text) ?? 0,
+                    tOuterThickness:
+                        int.tryParse(tOuterController.text) ?? 0,
+                    adapterOuterThickness:
+                        int.tryParse(adapterOuterController.text) ?? 0,
+                    uf: double.tryParse(ufController.text),
                     fixedGlassTakeoff:
                         int.tryParse(fixedGlassController.text) ?? 0,
                     sashGlassTakeoff:
@@ -484,6 +585,8 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                     name: nameController.text,
                     pricePerM2: double.tryParse(pricePerM2Controller.text) ?? 0,
                     massPerM2: double.tryParse(massPerM2Controller.text) ?? 0,
+                    ug: double.tryParse(ugController.text),
+                    psi: double.tryParse(psiController.text),
                   ));
                   break;
                 case CatalogType.blind:

--- a/lib/pdf/offer_pdf.dart
+++ b/lib/pdf/offer_pdf.dart
@@ -297,6 +297,8 @@ Future<void> printOfferPdf({
               blindMass +
               mechanismMass +
               accessoryMass;
+          final uw =
+              item.calculateUw(profile, glass, boxHeight: blind?.boxHeight ?? 0);
 
           double base = profileCost +
               glassCost +
@@ -347,6 +349,10 @@ Future<void> printOfferPdf({
             if (item.verticalSections != 1) pw.Text('V div: $vAdapters'),
             if (item.horizontalSections != 1) pw.Text('H div: $hAdapters'),
             pw.Text('Masa totale: ${totalMass.toStringAsFixed(2)} kg'),
+            if (glass.ug != null)
+              pw.Text('Ug: ${glass.ug!.toStringAsFixed(2)} W/m²K'),
+            if (uw != null)
+              pw.Text('Uw: ${uw.toStringAsFixed(2)} W/m²K'),
           ];
 
           rows.add(


### PR DESCRIPTION
## Summary
- allow entering Uf, Ug, Psi and outer profile thicknesses when managing profiles and glass
- compute Uw based on EN 10077-1 and show Ug/Uw in offer PDFs

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899032f7eb08324a47601f885c767d5