### PR TITLE
Gracefully handle customer migration errors

### DIFF
--- a/lib/data_migrations.dart
+++ b/lib/data_migrations.dart
@@ -1,17 +1,28 @@
+import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 import 'models.dart';
 
-Future<void> _migrateCustomers() async {
-  final box = await Hive.openBox<Customer>('customers');
-  for (final key in box.keys) {
-    final customer = box.get(key);
-    if (customer != null && (customer.email == null)) {
-      customer.email = '';
-      await customer.save();
+Future<bool> _migrateCustomers() async {
+  try {
+    final box = await Hive.openBox<Customer>('customers');
+    for (final key in box.keys) {
+      final customer = box.get(key);
+      if (customer != null && (customer.email == null)) {
+        customer.email = '';
+        await customer.save();
+      }
     }
+    return true;
+  } catch (e) {
+    debugPrint('Failed to migrate customers: $e');
+    return false;
   }
 }
 
-Future<void> runMigrations() async {
-  await _migrateCustomers();
+Future<List<String>> runMigrations() async {
+  final failures = <String>[];
+  if (!await _migrateCustomers()) {
+    failures.add('klientët');
+  }
+  return failures;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,7 +30,7 @@ void main() async {
   Hive.registerAdapter(OfferAdapter());
   Hive.registerAdapter(ExtraChargeAdapter());
 
-  await runMigrations();
+  final migrationFailures = await runMigrations();
 
   final failedBoxes = <String>[];
 
@@ -65,12 +65,20 @@ void main() async {
   await openBoxSafe<Accessory>('accessories');
   await openBoxSafe<Offer>('offers');
 
-  runApp(MyApp(failedBoxes: failedBoxes));
+  runApp(MyApp(
+    failedBoxes: failedBoxes,
+    migrationFailures: migrationFailures,
+  ));
 }
 
 class MyApp extends StatelessWidget {
   final List<String> failedBoxes;
-  const MyApp({super.key, required this.failedBoxes});
+  final List<String> migrationFailures;
+  const MyApp({
+    super.key,
+    required this.failedBoxes,
+    required this.migrationFailures,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -78,7 +86,10 @@ class MyApp extends StatelessWidget {
       title: 'TONI AL-PVC',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light,
-      home: WelcomePage(failedBoxes: failedBoxes),
+      home: WelcomePage(
+        failedBoxes: failedBoxes,
+        migrationFailures: migrationFailures,
+      ),
       routes: {
         '/home': (_) => const HomePage(),
       },

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -4,7 +4,12 @@ import '../theme/app_background.dart';
 
 class WelcomePage extends StatefulWidget {
   final List<String> failedBoxes;
-  const WelcomePage({super.key, this.failedBoxes = const []});
+  final List<String> migrationFailures;
+  const WelcomePage({
+    super.key,
+    this.failedBoxes = const [],
+    this.migrationFailures = const [],
+  });
 
   @override
   State<WelcomePage> createState() => _WelcomePageState();
@@ -14,14 +19,23 @@ class _WelcomePageState extends State<WelcomePage> {
   @override
   void initState() {
     super.initState();
-    if (widget.failedBoxes.isNotEmpty) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (widget.failedBoxes.isNotEmpty) {
         final names = widget.failedBoxes.join(', ');
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Disa të dhëna nuk u ngarkuan: $names')),
         );
-      });
-    }
+      }
+      if (widget.migrationFailures.isNotEmpty) {
+        final names = widget.migrationFailures.join(', ');
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+                'Disa të dhëna nuk u migruan: $names. Ju lutemi kontrolloni dhe rikuperoni manualisht nëse është e nevojshme.'),
+          ),
+        );
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
## Summary
- wrap customer box migration in try/catch and log errors instead of throwing
- collect migration failures and show a user-facing notice when migrations fail

## Testing
- `dart format lib/data_migrations.dart lib/main.dart lib/pages/welcome_page.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3e8b98348324b2d42697e74f9032