### PR TITLE
Add Hive migrations for Glass and Offer models

### DIFF
--- a/lib/data_migrations.dart
+++ b/lib/data_migrations.dart
@@ -19,10 +19,83 @@ Future<bool> _migrateCustomers() async {
   }
 }
 
+Future<bool> _migrateGlasses() async {
+  try {
+    final box = await Hive.openBox<Glass>('glasses');
+    for (final key in box.keys) {
+      final glass = box.get(key);
+      bool updated = false;
+      if (glass != null) {
+        if (glass.ug == null) {
+          glass.ug = 0;
+          updated = true;
+        }
+        if (glass.psi == null) {
+          glass.psi = 0;
+          updated = true;
+        }
+        if (updated) {
+          await glass.save();
+        }
+      }
+    }
+    return true;
+  } catch (e) {
+    debugPrint('Failed to migrate glasses: $e');
+    return false;
+  }
+}
+
+Future<bool> _migrateOffers() async {
+  try {
+    final box = await Hive.openBox<Offer>('offers');
+    for (final key in box.keys) {
+      final offer = box.get(key);
+      bool updated = false;
+      if (offer != null) {
+        final dynOffer = offer as dynamic;
+        if (dynOffer.extraCharges == null) {
+          offer.extraCharges = [];
+          updated = true;
+        }
+        if (dynOffer.discountPercent == null) {
+          offer.discountPercent = 0;
+          updated = true;
+        }
+        if (dynOffer.discountAmount == null) {
+          offer.discountAmount = 0;
+          updated = true;
+        }
+        if (dynOffer.notes == null) {
+          offer.notes = '';
+          updated = true;
+        }
+        if (dynOffer.lastEdited == null) {
+          offer.lastEdited = offer.date;
+          updated = true;
+        }
+        if (updated) {
+          await offer.save();
+        }
+      }
+    }
+    return true;
+  } catch (e) {
+    debugPrint('Failed to migrate offers: $e');
+    return false;
+  }
+}
+
 Future<List<String>> runMigrations() async {
   final failures = <String>[];
   if (!await _migrateCustomers()) {
     failures.add('klientët');
+  }
+  if (!await _migrateGlasses()) {
+    failures.add('xhamat');
+  }
+  if (!await _migrateOffers()) {
+    failures.add('ofertat');
   }
   return failures;
 }

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -123,8 +123,8 @@ class Glass extends HiveObject {
     required this.name,
     required this.pricePerM2,
     this.massPerM2 = 0,
-    this.ug,
-    this.psi,
+    this.ug = 0,
+    this.psi = 0,
   });
 }
 


### PR DESCRIPTION
## Summary
- add data migrations for `Glass` and `Offer` boxes, setting defaults for new fields
- include migrations in the startup sequence
- provide default values for thermal fields in `Glass`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 and unsigned)*

------
https://chatgpt.com/codex/tasks/task_e_689a4b6b18748324b4e201625703d298