### PR TITLE
Add default values for new Hive fields

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -36,45 +36,45 @@ class ProfileSet extends HiveObject {
   double priceAdapter; // Adapter (for double sash)
   @HiveField(5)
   double priceLlajsne; // Glazing bead
-  @HiveField(6)
+  @HiveField(6, defaultValue: 0)
   int pipeLength; // Standard pipe length in mm
-  @HiveField(7)
+  @HiveField(7, defaultValue: 0)
   int hekriOffsetL; // Hekri length difference for L profile
-  @HiveField(8)
+  @HiveField(8, defaultValue: 0)
   int hekriOffsetZ; // Hekri length difference for Z profile
-  @HiveField(9)
+  @HiveField(9, defaultValue: 0)
   int hekriOffsetT; // Hekri length difference for T profile
-  @HiveField(10)
+  @HiveField(10, defaultValue: 0)
   double massL; // Mass per meter for L profile
-  @HiveField(11)
+  @HiveField(11, defaultValue: 0)
   double massZ; // Mass per meter for Z profile
-  @HiveField(12)
+  @HiveField(12, defaultValue: 0)
   double massT; // Mass per meter for T profile
-  @HiveField(13)
+  @HiveField(13, defaultValue: 0)
   double massAdapter; // Mass per meter for Adapter
-  @HiveField(14)
+  @HiveField(14, defaultValue: 0)
   double massLlajsne; // Mass per meter for Glazing bead
-  @HiveField(15)
+  @HiveField(15, defaultValue: 0)
   int lInnerThickness; // Inner thickness of L profile
-  @HiveField(16)
+  @HiveField(16, defaultValue: 0)
   int zInnerThickness; // Inner thickness of Z profile
-  @HiveField(17)
+  @HiveField(17, defaultValue: 0)
   int tInnerThickness; // Inner thickness of T profile
-  @HiveField(18)
+  @HiveField(18, defaultValue: 0)
   int fixedGlassTakeoff; // Takeoff for fixed glass
-  @HiveField(19)
+  @HiveField(19, defaultValue: 0)
   int sashGlassTakeoff; // Takeoff for sash glass
-  @HiveField(20)
+  @HiveField(20, defaultValue: 0)
   int sashValue; // Value added for sash calculation
-  @HiveField(21)
+  @HiveField(21, defaultValue: 0)
   double? uf; // Thermal transmittance of profiles
-  @HiveField(22)
+  @HiveField(22, defaultValue: 0)
   int lOuterThickness; // Outer thickness of L profile
-  @HiveField(23)
+  @HiveField(23, defaultValue: 0)
   int zOuterThickness; // Outer thickness of Z profile
-  @HiveField(24)
+  @HiveField(24, defaultValue: 0)
   int tOuterThickness; // Outer thickness of T profile
-  @HiveField(25)
+  @HiveField(25, defaultValue: 0)
   int adapterOuterThickness; // Outer thickness of Adapter
 
   ProfileSet({
@@ -113,11 +113,11 @@ class Glass extends HiveObject {
   String name;
   @HiveField(1)
   double pricePerM2;
-  @HiveField(2)
+  @HiveField(2, defaultValue: 0)
   double massPerM2;
-  @HiveField(3)
+  @HiveField(3, defaultValue: 0)
   double? ug; // Thermal transmittance of glass
-  @HiveField(4)
+  @HiveField(4, defaultValue: 0)
   double? psi; // Linear thermal transmittance of glass
   Glass({
     required this.name,
@@ -134,9 +134,9 @@ class Blind extends HiveObject {
   String name;
   @HiveField(1)
   double pricePerM2;
-  @HiveField(2)
+  @HiveField(2, defaultValue: 0)
   int boxHeight; // height of the box in mm
-  @HiveField(3)
+  @HiveField(3, defaultValue: 0)
   double massPerM2;
   Blind({
     required this.name,
@@ -152,7 +152,7 @@ class Mechanism extends HiveObject {
   String name;
   @HiveField(1)
   double price;
-  @HiveField(2)
+  @HiveField(2, defaultValue: 0)
   double mass;
   Mechanism({required this.name, required this.price, this.mass = 0});
 }
@@ -163,7 +163,7 @@ class Accessory extends HiveObject {
   String name;
   @HiveField(1)
   double price;
-  @HiveField(2)
+  @HiveField(2, defaultValue: 0)
   double mass;
   Accessory({required this.name, required this.price, this.mass = 0});
 }
@@ -628,17 +628,17 @@ class Offer extends HiveObject {
   int customerIndex;
   @HiveField(2)
   DateTime date;
-  @HiveField(3)
+  @HiveField(3, defaultValue: const [])
   List<WindowDoorItem> items;
-  @HiveField(4)
+  @HiveField(4, defaultValue: 0)
   double profitPercent;
-  @HiveField(5)
+  @HiveField(5, defaultValue: const [])
   List<ExtraCharge> extraCharges;
-  @HiveField(6)
+  @HiveField(6, defaultValue: 0)
   double discountPercent;
-  @HiveField(7)
+  @HiveField(7, defaultValue: 0)
   double discountAmount;
-  @HiveField(8)
+  @HiveField(8, defaultValue: '')
   String notes;
   @HiveField(9)
   DateTime lastEdited;

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -66,26 +66,26 @@ class ProfileSetAdapter extends TypeAdapter<ProfileSet> {
       priceT: fields[3] as double,
       priceAdapter: fields[4] as double,
       priceLlajsne: fields[5] as double,
-      pipeLength: fields[6] as int,
-      hekriOffsetL: fields[7] as int,
-      hekriOffsetZ: fields[8] as int,
-      hekriOffsetT: fields[9] as int,
-      massL: fields[10] as double,
-      massZ: fields[11] as double,
-      massT: fields[12] as double,
-      massAdapter: fields[13] as double,
-      massLlajsne: fields[14] as double,
-      lInnerThickness: fields[15] as int,
-      zInnerThickness: fields[16] as int,
-      tInnerThickness: fields[17] as int,
-      fixedGlassTakeoff: fields[18] as int,
-      sashGlassTakeoff: fields[19] as int,
-      sashValue: fields[20] as int,
-      uf: fields[21] as double?,
-      lOuterThickness: fields[22] as int,
-      zOuterThickness: fields[23] as int,
-      tOuterThickness: fields[24] as int,
-      adapterOuterThickness: fields[25] as int,
+      pipeLength: fields[6] as int? ?? 0,
+      hekriOffsetL: fields[7] as int? ?? 0,
+      hekriOffsetZ: fields[8] as int? ?? 0,
+      hekriOffsetT: fields[9] as int? ?? 0,
+      massL: fields[10] as double? ?? 0,
+      massZ: fields[11] as double? ?? 0,
+      massT: fields[12] as double? ?? 0,
+      massAdapter: fields[13] as double? ?? 0,
+      massLlajsne: fields[14] as double? ?? 0,
+      lInnerThickness: fields[15] as int? ?? 0,
+      zInnerThickness: fields[16] as int? ?? 0,
+      tInnerThickness: fields[17] as int? ?? 0,
+      fixedGlassTakeoff: fields[18] as int? ?? 0,
+      sashGlassTakeoff: fields[19] as int? ?? 0,
+      sashValue: fields[20] as int? ?? 0,
+      uf: fields[21] as double? ?? 0,
+      lOuterThickness: fields[22] as int? ?? 0,
+      zOuterThickness: fields[23] as int? ?? 0,
+      tOuterThickness: fields[24] as int? ?? 0,
+      adapterOuterThickness: fields[25] as int? ?? 0,
     );
   }
 
@@ -171,9 +171,9 @@ class GlassAdapter extends TypeAdapter<Glass> {
     return Glass(
       name: fields[0] as String,
       pricePerM2: fields[1] as double,
-      massPerM2: fields[2] as double,
-      ug: fields[3] as double?,
-      psi: fields[4] as double?,
+      massPerM2: fields[2] as double? ?? 0,
+      ug: fields[3] as double? ?? 0,
+      psi: fields[4] as double? ?? 0,
     );
   }
 
@@ -217,8 +217,8 @@ class BlindAdapter extends TypeAdapter<Blind> {
     return Blind(
       name: fields[0] as String,
       pricePerM2: fields[1] as double,
-      boxHeight: fields[2] as int,
-      massPerM2: fields[3] as double,
+      boxHeight: fields[2] as int? ?? 0,
+      massPerM2: fields[3] as double? ?? 0,
     );
   }
 
@@ -260,7 +260,7 @@ class MechanismAdapter extends TypeAdapter<Mechanism> {
     return Mechanism(
       name: fields[0] as String,
       price: fields[1] as double,
-      mass: fields[2] as double,
+      mass: fields[2] as double? ?? 0,
     );
   }
 
@@ -300,7 +300,7 @@ class AccessoryAdapter extends TypeAdapter<Accessory> {
     return Accessory(
       name: fields[0] as String,
       price: fields[1] as double,
-      mass: fields[2] as double,
+      mass: fields[2] as double? ?? 0,
     );
   }
 
@@ -487,12 +487,12 @@ class OfferAdapter extends TypeAdapter<Offer> {
       id: fields[0] as String,
       customerIndex: fields[1] as int,
       date: fields[2] as DateTime,
-      items: (fields[3] as List).cast<WindowDoorItem>(),
-      profitPercent: fields[4] as double,
-      extraCharges: (fields[5] as List?)?.cast<ExtraCharge>(),
-      discountPercent: fields[6] as double,
-      discountAmount: fields[7] as double,
-      notes: fields[8] as String,
+      items: (fields[3] as List?)?.cast<WindowDoorItem>() ?? const [],
+      profitPercent: fields[4] as double? ?? 0,
+      extraCharges: (fields[5] as List?)?.cast<ExtraCharge>() ?? const [],
+      discountPercent: fields[6] as double? ?? 0,
+      discountAmount: fields[7] as double? ?? 0,
+      notes: fields[8] as String? ?? '',
       lastEdited: fields[9] as DateTime?,
     );
   }


### PR DESCRIPTION
## Summary
- provide defaultValue annotations for newly added Hive fields in models
- regenerate Hive adapters to supply safe defaults for legacy data

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a54eb28e8832486cc5eae469a26b3