### PR TITLE
Add offline multi-language support with runtime selection

### DIFF
--- a/assets/lang/de.json
+++ b/assets/lang/de.json
@@ -1,0 +1,14 @@
+{
+  "app_title": "TONI AL-PVC",
+  "menu_catalogs": "Preislisten",
+  "menu_customers": "Kunden",
+  "menu_offers": "Angebote",
+  "menu_production": "Produktion",
+  "enter": "Eingeben",
+  "language": "Sprache",
+  "address": "Rr. Ilir Konushevci, Nr. 80, Kamenica, Kosovo, 62000",
+  "phone": "+38344357639 | +38344268300",
+  "web": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "error_failed_boxes": "Einige Daten konnten nicht geladen werden: {names}",
+  "error_migration_failures": "Einige Daten konnten nicht migriert werden: {names}. Bitte prüfen und bei Bedarf manuell wiederherstellen."
+}

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1,0 +1,14 @@
+{
+  "app_title": "TONI AL-PVC",
+  "menu_catalogs": "Catalogs",
+  "menu_customers": "Customers",
+  "menu_offers": "Offers",
+  "menu_production": "Production",
+  "enter": "Enter",
+  "language": "Language",
+  "address": "Rr. Ilir Konushevci, No. 80, Kamenica, Kosovo, 62000",
+  "phone": "+38344357639 | +38344268300",
+  "web": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "error_failed_boxes": "Some data could not be loaded: {names}",
+  "error_migration_failures": "Some data could not be migrated: {names}. Please check and recover manually if necessary."
+}

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -1,0 +1,14 @@
+{
+  "app_title": "TONI AL-PVC",
+  "menu_catalogs": "Listes de prix",
+  "menu_customers": "Clients",
+  "menu_offers": "Offres",
+  "menu_production": "Production",
+  "enter": "Entrer",
+  "language": "Langue",
+  "address": "Rr. Ilir Konushevci, No. 80, Kamenica, Kosovo, 62000",
+  "phone": "+38344357639 | +38344268300",
+  "web": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "error_failed_boxes": "Certaines données n'ont pas pu être chargées : {names}",
+  "error_migration_failures": "Certaines données n'ont pas pu être migrées : {names}. Veuillez vérifier et récupérer manuellement si nécessaire."
+}

--- a/assets/lang/it.json
+++ b/assets/lang/it.json
@@ -1,0 +1,14 @@
+{
+  "app_title": "TONI AL-PVC",
+  "menu_catalogs": "Listini",
+  "menu_customers": "Clienti",
+  "menu_offers": "Offerte",
+  "menu_production": "Produzione",
+  "enter": "Entra",
+  "language": "Lingua",
+  "address": "Rr. Ilir Konushevci, Nr. 80, Kamenica, Kosovo, 62000",
+  "phone": "+38344357639 | +38344268300",
+  "web": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "error_failed_boxes": "Alcuni dati non hanno potuto essere caricati: {names}",
+  "error_migration_failures": "Alcuni dati non sono stati migrati: {names}. Per favore controlla e recupera manualmente se necessario."
+}

--- a/assets/lang/sq.json
+++ b/assets/lang/sq.json
@@ -1,0 +1,14 @@
+{
+  "app_title": "TONI AL-PVC",
+  "menu_catalogs": "Çmimore",
+  "menu_customers": "Klientët",
+  "menu_offers": "Ofertat",
+  "menu_production": "Prodhimi",
+  "enter": "Hyr",
+  "language": "Gjuha",
+  "address": "Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000",
+  "phone": "+38344357639 | +38344268300",
+  "web": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "error_failed_boxes": "Disa të dhëna nuk u ngarkuan: {names}",
+  "error_migration_failures": "Disa të dhëna nuk u migruan: {names}. Ju lutemi kontrolloni dhe rikuperoni manualisht nëse është e nevojshme."
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class AppLocalizations {
+  final Locale locale;
+  late Map<String, String> _localizedStrings;
+
+  AppLocalizations(this.locale);
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  Future<void> load() async {
+    final jsonString = await rootBundle.loadString('assets/lang/${locale.languageCode}.json');
+    final Map<String, dynamic> jsonMap = json.decode(jsonString);
+    _localizedStrings = jsonMap.map((key, value) => MapEntry(key, value.toString()));
+  }
+
+  String t(String key, {Map<String, String>? params}) {
+    var value = _localizedStrings[key] ?? key;
+    if (params != null) {
+      params.forEach((k, v) => value = value.replaceAll('{$k}', v));
+    }
+    return value;
+  }
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ['sq', 'en', 'de', 'it', 'fr'].contains(locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    final localizations = AppLocalizations(locale);
+    await localizations.load();
+    return localizations;
+  }
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) => false;
+}

--- a/lib/locale_controller.dart
+++ b/lib/locale_controller.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class LocaleController extends ChangeNotifier {
+  Locale _locale = const Locale('sq');
+
+  Locale get locale => _locale;
+
+  void setLocale(Locale locale) {
+    if (_locale == locale) return;
+    _locale = locale;
+    notifyListeners();
+  }
+}
+
+final localeController = LocaleController();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,10 @@ import 'pages/production_page.dart';
 import 'theme/app_theme.dart';
 import 'pages/welcome_page.dart';
 import 'data_migrations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'l10n/app_localizations.dart';
+import 'locale_controller.dart';
+import 'widgets/language_selector.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -67,16 +71,35 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'TONI AL-PVC',
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.light,
-      home: WelcomePage(
-        failedBoxes: failedBoxes,
-        migrationFailures: migrationFailures,
-      ),
-      routes: {
-        '/home': (_) => const HomePage(),
+    return AnimatedBuilder(
+      animation: localeController,
+      builder: (context, _) {
+        return MaterialApp(
+          title: 'TONI AL-PVC',
+          debugShowCheckedModeBanner: false,
+          theme: AppTheme.light,
+          locale: localeController.locale,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [
+            Locale('sq'),
+            Locale('en'),
+            Locale('de'),
+            Locale('it'),
+            Locale('fr'),
+          ],
+          home: WelcomePage(
+            failedBoxes: failedBoxes,
+            migrationFailures: migrationFailures,
+          ),
+          routes: {
+            '/home': (_) => const HomePage(),
+          },
+        );
       },
     );
   }
@@ -87,15 +110,23 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
     final items = [
-      _NavItem(
-          Icons.auto_awesome_motion_outlined, 'Çmimore', const CatalogsPage()),
-      _NavItem(Icons.people_outline, 'Klientët', const CustomersPage()),
-      _NavItem(Icons.description_outlined, 'Ofertat', const OffersPage()),
-      _NavItem(Icons.build, 'Prodhimi', const ProductionPage()),
+      _NavItem(Icons.auto_awesome_motion_outlined,
+          loc.t('menu_catalogs'), const CatalogsPage()),
+      _NavItem(Icons.people_outline, loc.t('menu_customers'),
+          const CustomersPage()),
+      _NavItem(Icons.description_outlined, loc.t('menu_offers'),
+          const OffersPage()),
+      _NavItem(Icons.build, loc.t('menu_production'),
+          const ProductionPage()),
     ];
 
     return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.t('app_title')),
+        actions: const [LanguageSelector()],
+      ),
       body: AppBackground(
         child: SafeArea(
           child: Center(

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import '../theme/app_background.dart';
+import '../l10n/app_localizations.dart';
+import '../widgets/language_selector.dart';
 
 class WelcomePage extends StatefulWidget {
   final List<String> failedBoxes;
@@ -23,15 +25,18 @@ class _WelcomePageState extends State<WelcomePage> {
       if (widget.failedBoxes.isNotEmpty) {
         final names = widget.failedBoxes.join(', ');
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Disa të dhëna nuk u ngarkuan: $names')),
+          SnackBar(
+            content: Text(AppLocalizations.of(context)
+                .t('error_failed_boxes', params: {'names': names})),
+          ),
         );
       }
       if (widget.migrationFailures.isNotEmpty) {
         final names = widget.migrationFailures.join(', ');
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(
-                'Disa të dhëna nuk u migruan: $names. Ju lutemi kontrolloni dhe rikuperoni manualisht nëse është e nevojshme.'),
+            content: Text(AppLocalizations.of(context)
+                .t('error_migration_failures', params: {'names': names})),
           ),
         );
       }
@@ -40,41 +45,51 @@ class _WelcomePageState extends State<WelcomePage> {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
     return Scaffold(
       body: AppBackground(
         child: SafeArea(
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.all(32),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Image.asset('assets/logo.png', width: 220)
-                      .animate()
-                      .fadeIn(duration: 600.ms)
-                      .slideY(begin: 0.2),
-                  const SizedBox(height: 24),
-                  const Text(
-                    'Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000',
-                    textAlign: TextAlign.center,
-                  ),
-                  const Text(
-                    '+38344357639 | +38344268300',
-                    textAlign: TextAlign.center,
-                  ),
-                  const Text(
-                    'www.tonialpvc.com | tonialpvc@gmail.com',
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 32),
-                  ElevatedButton(
-                    onPressed: () =>
-                        Navigator.pushReplacementNamed(context, '/home'),
-                    child: const Text('Hyr'),
-                  ).animate().fadeIn(duration: 220.ms, delay: 100.ms),
-                ],
+          child: Stack(
+            children: [
+              const Positioned(
+                top: 16,
+                right: 16,
+                child: LanguageSelector(),
               ),
-            ),
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(32),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Image.asset('assets/logo.png', width: 220)
+                          .animate()
+                          .fadeIn(duration: 600.ms)
+                          .slideY(begin: 0.2),
+                      const SizedBox(height: 24),
+                      Text(
+                        loc.t('address'),
+                        textAlign: TextAlign.center,
+                      ),
+                      Text(
+                        loc.t('phone'),
+                        textAlign: TextAlign.center,
+                      ),
+                      Text(
+                        loc.t('web'),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 32),
+                      ElevatedButton(
+                        onPressed: () =>
+                            Navigator.pushReplacementNamed(context, '/home'),
+                        child: Text(loc.t('enter')),
+                      ).animate().fadeIn(duration: 220.ms, delay: 100.ms),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/widgets/language_selector.dart
+++ b/lib/widgets/language_selector.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import '../locale_controller.dart';
+
+class LanguageSelector extends StatelessWidget {
+  const LanguageSelector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButtonHideUnderline(
+      child: DropdownButton<Locale>(
+        value: localeController.locale,
+        icon: const Icon(Icons.language),
+        onChanged: (Locale? locale) {
+          if (locale != null) {
+            localeController.setLocale(locale);
+          }
+        },
+        items: const [
+          DropdownMenuItem(value: Locale('sq'), child: Text('Shqip')),
+          DropdownMenuItem(value: Locale('en'), child: Text('English')),
+          DropdownMenuItem(value: Locale('de'), child: Text('Deutsch')),
+          DropdownMenuItem(value: Locale('it'), child: Text('Italiano')),
+          DropdownMenuItem(value: Locale('fr'), child: Text('Français')),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_localizations:
+    sdk: flutter
+
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -81,6 +84,7 @@ flutter:
   assets:
     - assets/fonts/
     - assets/logo.png
+    - assets/lang/
 
   fonts:
     - family: Montserrat


### PR DESCRIPTION
## Summary
- add localization assets for Albanian, English, German, Italian and French
- introduce localization loader and locale controller
- allow language switching on Welcome and Home screens

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1a030e348324919369cca97b41c6