### PR TITLE
Add offline localization with multi-language support

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,5 @@
+arb-dir: lib/l10n
+template-arb-file: app_sq.arb
+output-localization-file: app_localizations.dart
+output-class: AppLocalizations
+synthetic-package: false

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1,0 +1,23 @@
+{
+  "appTitle": "TONI AL-PVC",
+  "homeCatalogs": "Preisliste",
+  "homeCustomers": "Kunden",
+  "homeOffers": "Angebote",
+  "homeProduction": "Produktion",
+  "welcomeAddress": "Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000",
+  "welcomePhones": "+38344357639 | +38344268300",
+  "welcomeWebsite": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "welcomeEnter": "Betreten",
+  "snackLoadFailure": "Einige Daten konnten nicht geladen werden: {names}",
+  "@snackLoadFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  },
+  "snackMigrationFailure": "Einige Daten konnten nicht migriert werden: {names}. Bitte prüfen und ggf. manuell wiederherstellen.",
+  "@snackMigrationFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,23 @@
+{
+  "appTitle": "TONI AL-PVC",
+  "homeCatalogs": "Price List",
+  "homeCustomers": "Customers",
+  "homeOffers": "Offers",
+  "homeProduction": "Production",
+  "welcomeAddress": "Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000",
+  "welcomePhones": "+38344357639 | +38344268300",
+  "welcomeWebsite": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "welcomeEnter": "Enter",
+  "snackLoadFailure": "Some data failed to load: {names}",
+  "@snackLoadFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  },
+  "snackMigrationFailure": "Some data failed to migrate: {names}. Please check and recover manually if necessary.",
+  "@snackMigrationFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  }
+}

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,0 +1,23 @@
+{
+  "appTitle": "TONI AL-PVC",
+  "homeCatalogs": "Tarifs",
+  "homeCustomers": "Clients",
+  "homeOffers": "Offres",
+  "homeProduction": "Production",
+  "welcomeAddress": "Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000",
+  "welcomePhones": "+38344357639 | +38344268300",
+  "welcomeWebsite": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "welcomeEnter": "Entrer",
+  "snackLoadFailure": "Certaines données n'ont pas été chargées : {names}",
+  "@snackLoadFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  },
+  "snackMigrationFailure": "Certaines données n'ont pas été migrées : {names}. Veuillez vérifier et récupérer manuellement si nécessaire.",
+  "@snackMigrationFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  }
+}

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1,0 +1,23 @@
+{
+  "appTitle": "TONI AL-PVC",
+  "homeCatalogs": "Listino prezzi",
+  "homeCustomers": "Clienti",
+  "homeOffers": "Offerte",
+  "homeProduction": "Produzione",
+  "welcomeAddress": "Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000",
+  "welcomePhones": "+38344357639 | +38344268300",
+  "welcomeWebsite": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "welcomeEnter": "Entra",
+  "snackLoadFailure": "Alcuni dati non sono stati caricati: {names}",
+  "@snackLoadFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  },
+  "snackMigrationFailure": "Alcuni dati non sono stati migrati: {names}. Controlla e ripristina manualmente se necessario.",
+  "@snackMigrationFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  }
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/widgets.dart';
+
+class AppLocalizations {
+  AppLocalizations(this.locale);
+
+  final Locale locale;
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const supportedLocales = [
+    Locale('sq'),
+    Locale('en'),
+    Locale('de'),
+    Locale('it'),
+    Locale('fr'),
+  ];
+
+  static const Map<String, Map<String, String>> _localizedValues = {
+    'sq': {
+      'appTitle': 'TONI AL-PVC',
+      'homeCatalogs': 'Çmimore',
+      'homeCustomers': 'Klientët',
+      'homeOffers': 'Ofertat',
+      'homeProduction': 'Prodhimi',
+      'welcomeAddress': 'Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000',
+      'welcomePhones': '+38344357639 | +38344268300',
+      'welcomeWebsite': 'www.tonialpvc.com | tonialpvc@gmail.com',
+      'welcomeEnter': 'Hyr',
+      'snackLoadFailure': 'Disa të dhëna nuk u ngarkuan: {names}',
+      'snackMigrationFailure': 'Disa të dhëna nuk u migruan: {names}. Ju lutemi kontrolloni dhe rikuperoni manualisht nëse është e nevojshme.',
+    },
+    'en': {
+      'appTitle': 'TONI AL-PVC',
+      'homeCatalogs': 'Price List',
+      'homeCustomers': 'Customers',
+      'homeOffers': 'Offers',
+      'homeProduction': 'Production',
+      'welcomeAddress': 'Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000',
+      'welcomePhones': '+38344357639 | +38344268300',
+      'welcomeWebsite': 'www.tonialpvc.com | tonialpvc@gmail.com',
+      'welcomeEnter': 'Enter',
+      'snackLoadFailure': 'Some data failed to load: {names}',
+      'snackMigrationFailure': 'Some data failed to migrate: {names}. Please check and recover manually if necessary.',
+    },
+    'de': {
+      'appTitle': 'TONI AL-PVC',
+      'homeCatalogs': 'Preisliste',
+      'homeCustomers': 'Kunden',
+      'homeOffers': 'Angebote',
+      'homeProduction': 'Produktion',
+      'welcomeAddress': 'Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000',
+      'welcomePhones': '+38344357639 | +38344268300',
+      'welcomeWebsite': 'www.tonialpvc.com | tonialpvc@gmail.com',
+      'welcomeEnter': 'Betreten',
+      'snackLoadFailure': 'Einige Daten konnten nicht geladen werden: {names}',
+      'snackMigrationFailure': 'Einige Daten konnten nicht migriert werden: {names}. Bitte prüfen und ggf. manuell wiederherstellen.',
+    },
+    'it': {
+      'appTitle': 'TONI AL-PVC',
+      'homeCatalogs': 'Listino prezzi',
+      'homeCustomers': 'Clienti',
+      'homeOffers': 'Offerte',
+      'homeProduction': 'Produzione',
+      'welcomeAddress': 'Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000',
+      'welcomePhones': '+38344357639 | +38344268300',
+      'welcomeWebsite': 'www.tonialpvc.com | tonialpvc@gmail.com',
+      'welcomeEnter': 'Entra',
+      'snackLoadFailure': 'Alcuni dati non sono stati caricati: {names}',
+      'snackMigrationFailure': 'Alcuni dati non sono stati migrati: {names}. Controlla e ripristina manualmente se necessario.',
+    },
+    'fr': {
+      'appTitle': 'TONI AL-PVC',
+      'homeCatalogs': 'Tarifs',
+      'homeCustomers': 'Clients',
+      'homeOffers': 'Offres',
+      'homeProduction': 'Production',
+      'welcomeAddress': 'Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000',
+      'welcomePhones': '+38344357639 | +38344268300',
+      'welcomeWebsite': 'www.tonialpvc.com | tonialpvc@gmail.com',
+      'welcomeEnter': 'Entrer',
+      'snackLoadFailure': "Certaines données n'ont pas été chargées : {names}",
+      'snackMigrationFailure': "Certaines données n'ont pas été migrées : {names}. Veuillez vérifier et récupérer manuellement si nécessaire.",
+    },
+  };
+
+  String get appTitle => _localizedValues[locale.languageCode]!['appTitle']!;
+  String get homeCatalogs => _localizedValues[locale.languageCode]!['homeCatalogs']!;
+  String get homeCustomers => _localizedValues[locale.languageCode]!['homeCustomers']!;
+  String get homeOffers => _localizedValues[locale.languageCode]!['homeOffers']!;
+  String get homeProduction => _localizedValues[locale.languageCode]!['homeProduction']!;
+  String get welcomeAddress => _localizedValues[locale.languageCode]!['welcomeAddress']!;
+  String get welcomePhones => _localizedValues[locale.languageCode]!['welcomePhones']!;
+  String get welcomeWebsite => _localizedValues[locale.languageCode]!['welcomeWebsite']!;
+  String get welcomeEnter => _localizedValues[locale.languageCode]!['welcomeEnter']!;
+
+  String snackLoadFailure(String names) =>
+      _localizedValues[locale.languageCode]!['snackLoadFailure']!.replaceFirst('{names}', names);
+  String snackMigrationFailure(String names) =>
+      _localizedValues[locale.languageCode]!['snackMigrationFailure']!.replaceFirst('{names}', names);
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) =>
+      AppLocalizations.supportedLocales.map((e) => e.languageCode).contains(locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async => AppLocalizations(locale);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -1,0 +1,23 @@
+{
+  "appTitle": "TONI AL-PVC",
+  "homeCatalogs": "Çmimore",
+  "homeCustomers": "Klientët",
+  "homeOffers": "Ofertat",
+  "homeProduction": "Prodhimi",
+  "welcomeAddress": "Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000",
+  "welcomePhones": "+38344357639 | +38344268300",
+  "welcomeWebsite": "www.tonialpvc.com | tonialpvc@gmail.com",
+  "welcomeEnter": "Hyr",
+  "snackLoadFailure": "Disa të dhëna nuk u ngarkuan: {names}",
+  "@snackLoadFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  },
+  "snackMigrationFailure": "Disa të dhëna nuk u migruan: {names}. Ju lutemi kontrolloni dhe rikuperoni manualisht nëse është e nevojshme.",
+  "@snackMigrationFailure": {
+    "placeholders": {
+      "names": {}
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'l10n/app_localizations.dart';
 import 'theme/app_background.dart';
 import 'widgets/glass_card.dart';
 import 'theme/app_colors.dart';
@@ -68,7 +70,15 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'TONI AL-PVC',
+      locale: const Locale('sq'),
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light,
       home: WelcomePage(
@@ -87,12 +97,15 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final items = [
-      _NavItem(
-          Icons.auto_awesome_motion_outlined, 'Çmimore', const CatalogsPage()),
-      _NavItem(Icons.people_outline, 'Klientët', const CustomersPage()),
-      _NavItem(Icons.description_outlined, 'Ofertat', const OffersPage()),
-      _NavItem(Icons.build, 'Prodhimi', const ProductionPage()),
+      _NavItem(Icons.auto_awesome_motion_outlined, l10n.homeCatalogs,
+          const CatalogsPage()),
+      _NavItem(Icons.people_outline, l10n.homeCustomers,
+          const CustomersPage()),
+      _NavItem(Icons.description_outlined, l10n.homeOffers,
+          const OffersPage()),
+      _NavItem(Icons.build, l10n.homeProduction, const ProductionPage()),
     ];
 
     return Scaffold(

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import '../theme/app_background.dart';
+import 'package:crystal_upvc/l10n/app_localizations.dart';
 
 class WelcomePage extends StatefulWidget {
   final List<String> failedBoxes;
@@ -22,16 +23,17 @@ class _WelcomePageState extends State<WelcomePage> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (widget.failedBoxes.isNotEmpty) {
         final names = widget.failedBoxes.join(', ');
+        final l10n = AppLocalizations.of(context)!;
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Disa të dhëna nuk u ngarkuan: $names')),
+          SnackBar(content: Text(l10n.snackLoadFailure(names))),
         );
       }
       if (widget.migrationFailures.isNotEmpty) {
         final names = widget.migrationFailures.join(', ');
+        final l10n = AppLocalizations.of(context)!;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(
-                'Disa të dhëna nuk u migruan: $names. Ju lutemi kontrolloni dhe rikuperoni manualisht nëse është e nevojshme.'),
+            content: Text(l10n.snackMigrationFailure(names)),
           ),
         );
       }
@@ -40,6 +42,7 @@ class _WelcomePageState extends State<WelcomePage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Scaffold(
       body: AppBackground(
         child: SafeArea(
@@ -54,23 +57,23 @@ class _WelcomePageState extends State<WelcomePage> {
                       .fadeIn(duration: 600.ms)
                       .slideY(begin: 0.2),
                   const SizedBox(height: 24),
-                  const Text(
-                    'Rr. Ilir Konushevci, Nr. 80, Kamenicë, Kosovë, 62000',
+                  Text(
+                    l10n.welcomeAddress,
                     textAlign: TextAlign.center,
                   ),
-                  const Text(
-                    '+38344357639 | +38344268300',
+                  Text(
+                    l10n.welcomePhones,
                     textAlign: TextAlign.center,
                   ),
-                  const Text(
-                    'www.tonialpvc.com | tonialpvc@gmail.com',
+                  Text(
+                    l10n.welcomeWebsite,
                     textAlign: TextAlign.center,
                   ),
                   const SizedBox(height: 32),
                   ElevatedButton(
                     onPressed: () =>
                         Navigator.pushReplacementNamed(context, '/home'),
-                    child: const Text('Hyr'),
+                    child: Text(l10n.welcomeEnter),
                   ).animate().fadeIn(duration: 220.ms, delay: 100.ms),
                 ],
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
 
   # The following adds the Cupertino Icons font to your application.
@@ -72,6 +74,7 @@ flutter_icons:
 # The following section is specific to Flutter packages.
 flutter:
 
+  generate: true
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
## Summary
- add `flutter_localizations` and offline l10n config
- create translation maps for Albanian, English, German, Italian and French
- localize app title, home menu and welcome page with new `AppLocalizations`

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7ac9f3a083248afdf29a8db41d16