### PR TITLE
Localize window door item page

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -70,6 +70,72 @@ class AppLocalizations {
       'add': 'Shto',
       'delete': 'Fshij',
       'save': 'Ruaj',
+      'addCustomerFirst': 'Ju lutem shtoni së pari një klient të ri!',
+      'createOffer': 'Krijo Ofertë',
+      'searchCustomer': 'Kërko klientin',
+      'noResults': 'Nuk ka rezultate',
+      'profitPercent': 'Fitimi %',
+      'offerSearchHint':
+          'Kërko sipas emrit të klientit ose numrit të ofertës',
+      'deleteOffer': 'Fshij Ofertën',
+      'deleteOfferConfirm':
+          'A jeni i sigurt që dëshironi ta fshini këtë ofertë?',
+      'chooseCustomer': 'Zgjidh Klientin',
+      'profit': 'Fitimi',
+      'setProfitPercent': 'Vendos përqindjen e fitimit',
+      'editDeleteWindowDoor': 'Ndrysho/Fshij Dritare/Derë',
+      'confirmDeleteQuestion': 'Dëshironi ta fshini këtë?',
+      'edit': 'Ndrysho',
+      'description': 'Përshkrimi',
+      'amount': 'Shuma',
+      'addExtra': 'Shto ekstra',
+      'totalWithoutProfit': 'Totali pa fitim (0%)',
+      'withProfit': 'Me fitim',
+      'totalProfit': 'Fitimi total',
+      'addWindowDoor': 'Shto Dritare/Derë',
+      'editWindowDoor': 'Ndrysho Dritaren/Derën',
+      'designWindowDoor': 'Dizajno dritare/derë',
+      'designImageAttached': 'Imazhi i dizajnit u bashkangjit',
+      'clickAddPhoto': 'Kliko për të \\nvendosë foton',
+      'name': 'Emri',
+      'widthMm': 'Gjerësia (mm)',
+      'heightMm': 'Lartësia (mm)',
+      'quantity': 'Sasia',
+      'basePriceOptional': 'Çmimi 0% (Opsional)',
+      'priceOptional': 'Çmimi me fitim (Opsional)',
+      'verticalSections': 'Sektorë Vertikal',
+      'horizontalSections': 'Sektorë Horizontal',
+      'extra1Name': 'Emri i shtesës 1',
+      'extra1Price': 'Çmimi i shtesës 1',
+      'extra2Name': 'Emri i shtesës 2',
+      'extra2Price': 'Çmimi i shtesës 2',
+      'notes': 'Shënime',
+      'mechanismOptional': 'Mekanizmi (Opsional)',
+      'none': 'Asnjë',
+      'blindOptional': 'Roleta (Opsional)',
+      'accessoryOptional': 'Aksesor (Opsional)',
+      'fillAllRequired':
+          'Ju lutem plotësoni të gjitha të dhënat e kërkuara!',
+      'saveChanges': 'Ruaj ndryshimet?',
+      'saveChangesQuestion':
+          'Dëshironi t\\'i ruani ndryshimet para se të dilni?',
+      'no': 'Jo',
+      'yes': 'Po',
+      'sectionWidthExceeds':
+          'Gjerësia e sektorit e kalon gjerësinë totale!',
+      'sectionHeightExceeds':
+          'Lartësia e sektorit e kalon lartësinë totale!',
+      'fixed': 'Fikse',
+      'openWithSash': 'Me hapje (Me krah)',
+      'sectorWidths': 'Gjerësitë e sektorëve (mm)',
+      'sectorWidth': 'Gjerësia e sektorit (mm)',
+      'sectorHeights': 'Lartësitë e sektorëve (mm)',
+      'sectorHeight': 'Lartësia e sektorit (mm)',
+      'width': 'Gjerësia',
+      'height': 'Lartësia',
+      'auto': 'auto',
+      'verticalDivision': 'Ndarja Vertikale',
+      'horizontalDivision': 'Ndarja Horizontale',
     },
     'en': {
       'appTitle': 'TONI AL-PVC',
@@ -155,6 +221,46 @@ class AppLocalizations {
       'totalWithoutProfit': 'Total without profit (0%)',
       'withProfit': 'With Profit',
       'totalProfit': 'Total Profit',
+      'addWindowDoor': 'Add Window/Door',
+      'editWindowDoor': 'Edit Window/Door',
+      'designWindowDoor': 'Design window/door',
+      'designImageAttached': 'Design image attached',
+      'clickAddPhoto': 'Click to \\nadd photo',
+      'name': 'Name',
+      'widthMm': 'Width (mm)',
+      'heightMm': 'Height (mm)',
+      'quantity': 'Quantity',
+      'basePriceOptional': 'Price 0% (Optional)',
+      'priceOptional': 'Price with profit (Optional)',
+      'verticalSections': 'Vertical Sections',
+      'horizontalSections': 'Horizontal Sections',
+      'extra1Name': 'Extra 1 name',
+      'extra1Price': 'Extra 1 price',
+      'extra2Name': 'Extra 2 name',
+      'extra2Price': 'Extra 2 price',
+      'notes': 'Notes',
+      'mechanismOptional': 'Mechanism (Optional)',
+      'none': 'None',
+      'blindOptional': 'Roller Shutter (Optional)',
+      'accessoryOptional': 'Accessory (Optional)',
+      'fillAllRequired': 'Please fill all required fields!',
+      'saveChanges': 'Save changes?',
+      'saveChangesQuestion': 'Do you want to save changes before exiting?',
+      'no': 'No',
+      'yes': 'Yes',
+      'sectionWidthExceeds': 'Section width exceeds total width!',
+      'sectionHeightExceeds': 'Section height exceeds total height!',
+      'fixed': 'Fixed',
+      'openWithSash': 'Openable (With sash)',
+      'sectorWidths': 'Sector widths (mm)',
+      'sectorWidth': 'Sector width (mm)',
+      'sectorHeights': 'Sector heights (mm)',
+      'sectorHeight': 'Sector height (mm)',
+      'width': 'Width',
+      'height': 'Height',
+      'auto': 'auto',
+      'verticalDivision': 'Vertical division',
+      'horizontalDivision': 'Horizontal division',
     },
     'de': {
       'appTitle': 'TONI AL-PVC',
@@ -240,6 +346,50 @@ class AppLocalizations {
       'totalWithoutProfit': 'Summe ohne Gewinn (0%)',
       'withProfit': 'Mit Gewinn',
       'totalProfit': 'Gesamtgewinn',
+      'addWindowDoor': 'Fenster/Tür hinzufügen',
+      'editWindowDoor': 'Fenster/Tür bearbeiten',
+      'designWindowDoor': 'Fenster/Tür entwerfen',
+      'designImageAttached': 'Designbild angehängt',
+      'clickAddPhoto': 'Klicken zum \\nFoto hinzufügen',
+      'name': 'Name',
+      'widthMm': 'Breite (mm)',
+      'heightMm': 'Höhe (mm)',
+      'quantity': 'Menge',
+      'basePriceOptional': 'Preis 0% (Optional)',
+      'priceOptional': 'Preis mit Gewinn (Optional)',
+      'verticalSections': 'Vertikale Sektoren',
+      'horizontalSections': 'Horizontale Sektoren',
+      'extra1Name': 'Name Zusatz 1',
+      'extra1Price': 'Preis Zusatz 1',
+      'extra2Name': 'Name Zusatz 2',
+      'extra2Price': 'Preis Zusatz 2',
+      'notes': 'Notizen',
+      'mechanismOptional': 'Mechanismus (Optional)',
+      'none': 'Keiner',
+      'blindOptional': 'Rollladen (Optional)',
+      'accessoryOptional': 'Zubehör (Optional)',
+      'fillAllRequired':
+          'Bitte füllen Sie alle erforderlichen Felder aus!',
+      'saveChanges': 'Änderungen speichern?',
+      'saveChangesQuestion':
+          'Möchten Sie die Änderungen vor dem Verlassen speichern?',
+      'no': 'Nein',
+      'yes': 'Ja',
+      'sectionWidthExceeds':
+          'Sektorbreite überschreitet Gesamtbreite!',
+      'sectionHeightExceeds':
+          'Sektorhöhe überschreitet Gesamthöhe!',
+      'fixed': 'Fest',
+      'openWithSash': 'Öffnend (mit Flügel)',
+      'sectorWidths': 'Sektorbreiten (mm)',
+      'sectorWidth': 'Sektorbreite (mm)',
+      'sectorHeights': 'Sektorhöhen (mm)',
+      'sectorHeight': 'Sektorhöhe (mm)',
+      'width': 'Breite',
+      'height': 'Höhe',
+      'auto': 'auto',
+      'verticalDivision': 'Vertikale Teilung',
+      'horizontalDivision': 'Horizontale Teilung',
     },
     'fr': {
       'appTitle': 'TONI AL-PVC',
@@ -325,6 +475,50 @@ class AppLocalizations {
       'totalWithoutProfit': 'Total sans bénéfice (0 %)',
       'withProfit': 'Avec bénéfice',
       'totalProfit': 'Bénéfice total',
+      'addWindowDoor': 'Ajouter Fenêtre/Porte',
+      'editWindowDoor': 'Modifier Fenêtre/Porte',
+      'designWindowDoor': 'Concevoir fenêtre/porte',
+      'designImageAttached': 'Image de conception ajoutée',
+      'clickAddPhoto': 'Cliquez pour \\najouter une photo',
+      'name': 'Nom',
+      'widthMm': 'Largeur (mm)',
+      'heightMm': 'Hauteur (mm)',
+      'quantity': 'Quantité',
+      'basePriceOptional': 'Prix 0 % (Optionnel)',
+      'priceOptional': 'Prix avec profit (Optionnel)',
+      'verticalSections': 'Sections verticales',
+      'horizontalSections': 'Sections horizontales',
+      'extra1Name': 'Nom supplément 1',
+      'extra1Price': 'Prix supplément 1',
+      'extra2Name': 'Nom supplément 2',
+      'extra2Price': 'Prix supplément 2',
+      'notes': 'Notes',
+      'mechanismOptional': 'Mécanisme (Optionnel)',
+      'none': 'Aucun',
+      'blindOptional': 'Volet roulant (Optionnel)',
+      'accessoryOptional': 'Accessoire (Optionnel)',
+      'fillAllRequired':
+          'Veuillez remplir tous les champs requis !',
+      'saveChanges': 'Enregistrer les modifications ?',
+      'saveChangesQuestion':
+          'Voulez-vous enregistrer les modifications avant de quitter ?',
+      'no': 'Non',
+      'yes': 'Oui',
+      'sectionWidthExceeds':
+          'La largeur de la section dépasse la largeur totale !',
+      'sectionHeightExceeds':
+          'La hauteur de la section dépasse la hauteur totale !',
+      'fixed': 'Fixe',
+      'openWithSash': 'Ouvrant (Avec battant)',
+      'sectorWidths': 'Largeurs des secteurs (mm)',
+      'sectorWidth': 'Largeur du secteur (mm)',
+      'sectorHeights': 'Hauteurs des secteurs (mm)',
+      'sectorHeight': 'Hauteur du secteur (mm)',
+      'width': 'Largeur',
+      'height': 'Hauteur',
+      'auto': 'auto',
+      'verticalDivision': 'Division verticale',
+      'horizontalDivision': 'Division horizontale',
     },
     'it': {
       'appTitle': 'TONI AL-PVC',
@@ -410,6 +604,50 @@ class AppLocalizations {
       'totalWithoutProfit': 'Totale senza profitto (0%)',
       'withProfit': 'Con profitto',
       'totalProfit': 'Profitto totale',
+      'addWindowDoor': 'Aggiungi Finestra/Porta',
+      'editWindowDoor': 'Modifica Finestra/Porta',
+      'designWindowDoor': 'Progetta finestra/porta',
+      'designImageAttached': 'Immagine del progetto allegata',
+      'clickAddPhoto': 'Clicca per \\naggiungere foto',
+      'name': 'Nome',
+      'widthMm': 'Larghezza (mm)',
+      'heightMm': 'Altezza (mm)',
+      'quantity': 'Quantità',
+      'basePriceOptional': 'Prezzo 0% (Opzionale)',
+      'priceOptional': 'Prezzo con profitto (Opzionale)',
+      'verticalSections': 'Sezioni verticali',
+      'horizontalSections': 'Sezioni orizzontali',
+      'extra1Name': 'Nome extra 1',
+      'extra1Price': 'Prezzo extra 1',
+      'extra2Name': 'Nome extra 2',
+      'extra2Price': 'Prezzo extra 2',
+      'notes': 'Note',
+      'mechanismOptional': 'Meccanismo (Opzionale)',
+      'none': 'Nessuno',
+      'blindOptional': 'Tapparella (Opzionale)',
+      'accessoryOptional': 'Accessorio (Opzionale)',
+      'fillAllRequired':
+          'Si prega di compilare tutti i campi richiesti!',
+      'saveChanges': 'Salvare le modifiche?',
+      'saveChangesQuestion':
+          'Vuoi salvare le modifiche prima di uscire?',
+      'no': 'No',
+      'yes': 'Sì',
+      'sectionWidthExceeds':
+          'La larghezza della sezione supera la larghezza totale!',
+      'sectionHeightExceeds':
+          'L\'altezza della sezione supera l\'altezza totale!',
+      'fixed': 'Fisso',
+      'openWithSash': 'Apribile (Con anta)',
+      'sectorWidths': 'Larghezze dei settori (mm)',
+      'sectorWidth': 'Larghezza del settore (mm)',
+      'sectorHeights': 'Altezze dei settori (mm)',
+      'sectorHeight': 'Altezza del settore (mm)',
+      'width': 'Larghezza',
+      'height': 'Altezza',
+      'auto': 'auto',
+      'verticalDivision': 'Divisione verticale',
+      'horizontalDivision': 'Divisione orizzontale',
     },
   };
 
@@ -498,6 +736,51 @@ class AppLocalizations {
   String get totalWithoutProfit => _t('totalWithoutProfit');
   String get withProfit => _t('withProfit');
   String get totalProfit => _t('totalProfit');
+  String get addWindowDoor => _t('addWindowDoor');
+  String get editWindowDoor => _t('editWindowDoor');
+  String get designWindowDoor => _t('designWindowDoor');
+  String get designImageAttached => _t('designImageAttached');
+  String get clickAddPhoto => _t('clickAddPhoto');
+  String get name => _t('name');
+  String get widthMm => _t('widthMm');
+  String get heightMm => _t('heightMm');
+  String get quantity => _t('quantity');
+  String get basePriceOptional => _t('basePriceOptional');
+  String get priceOptional => _t('priceOptional');
+  String get verticalSections => _t('verticalSections');
+  String get horizontalSections => _t('horizontalSections');
+  String get extra1Name => _t('extra1Name');
+  String get extra1Price => _t('extra1Price');
+  String get extra2Name => _t('extra2Name');
+  String get extra2Price => _t('extra2Price');
+  String get notes => _t('notes');
+  String get mechanismOptional => _t('mechanismOptional');
+  String get none => _t('none');
+  String get blindOptional => _t('blindOptional');
+  String get accessoryOptional => _t('accessoryOptional');
+  String get fillAllRequired => _t('fillAllRequired');
+  String get saveChanges => _t('saveChanges');
+  String get saveChangesQuestion => _t('saveChangesQuestion');
+  String get no => _t('no');
+  String get yes => _t('yes');
+  String get sectionWidthExceeds => _t('sectionWidthExceeds');
+  String get sectionHeightExceeds => _t('sectionHeightExceeds');
+  String get fixed => _t('fixed');
+  String get openWithSash => _t('openWithSash');
+  String get sectorWidths => _t('sectorWidths');
+  String get sectorWidth => _t('sectorWidth');
+  String get sectorHeights => _t('sectorHeights');
+  String get sectorHeight => _t('sectorHeight');
+  String get width => _t('width');
+  String get height => _t('height');
+  String get auto => _t('auto');
+  String get verticalDivision => _t('verticalDivision');
+  String get horizontalDivision => _t('horizontalDivision');
+
+  String widthAutoLabel(int index) => '${width} $index (${auto})';
+  String widthLabel(int index) => '${width} $index';
+  String heightAutoLabel(int index) => '${height} $index (${auto})';
+  String heightLabel(int index) => '${height} $index';
 
   String get localeName => locale.languageCode;
 

--- a/lib/pages/window_door_item_page.dart
+++ b/lib/pages/window_door_item_page.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import '../models.dart';
 import '../theme/app_colors.dart';
 import 'window_door_designer_page.dart';
+import '../l10n/app_localizations.dart';
 
 class WindowDoorItemPage extends StatefulWidget {
   final void Function(WindowDoorItem) onSave;
@@ -129,17 +130,18 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return WillPopScope(
         onWillPop: _onWillPop,
         child: Scaffold(
             backgroundColor: Colors.white,
             appBar: AppBar(
                 title: Text(widget.existingItem == null
-                    ? 'Shto Dritare/Derë'
-                    : 'Ndrysho Dritaren/Derën'),
+                    ? l10n.addWindowDoor
+                    : l10n.editWindowDoor),
                 actions: [
                   IconButton(
-                    tooltip: 'Design window/door',
+                    tooltip: l10n.designWindowDoor,
                     icon: const Icon(Icons.design_services),
                     onPressed: () async {
                       final bytes = await Navigator.push<Uint8List>(
@@ -150,8 +152,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                       if (bytes != null && mounted) {
                         setState(() => _designImageBytes = bytes);
                         ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(
-                              content: Text('Design image attached')),
+                          SnackBar(
+                              content: Text(l10n.designImageAttached)),
                         );
                       }
                     },
@@ -205,9 +207,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                                             width: 120,
                                             height: 120,
                                             color: AppColors.grey300,
-                                            child: const Center(
-                                              child: Text(
-                                                  'Kliko për të \nvendosë foton'),
+                                            child: Center(
+                                              child: Text(l10n.clickAddPhoto),
                                             ),
                                           )),
                             if (_designImageBytes != null)
@@ -223,15 +224,15 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                             TextField(
                                 controller: nameController,
                                 decoration:
-                                    const InputDecoration(labelText: 'Emri')),
+                                    InputDecoration(labelText: l10n.name)),
                             const SizedBox(height: 12),
                             Row(
                               children: [
                                 Expanded(
                                   child: TextField(
                                     controller: widthController,
-                                    decoration: const InputDecoration(
-                                        labelText: 'Gjerësia (mm)'),
+                                    decoration: InputDecoration(
+                                        labelText: l10n.widthMm),
                                     keyboardType: TextInputType.number,
                                     onChanged: (_) => _recalculateWidths(),
                                   ),
@@ -240,8 +241,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                                 Expanded(
                                   child: TextField(
                                     controller: heightController,
-                                    decoration: const InputDecoration(
-                                        labelText: 'Lartësia (mm)'),
+                                    decoration: InputDecoration(
+                                        labelText: l10n.heightMm),
                                     keyboardType: TextInputType.number,
                                     onChanged: (_) => _recalculateHeights(),
                                   ),
@@ -254,16 +255,16 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                                 Expanded(
                                   child: TextField(
                                       controller: quantityController,
-                                      decoration: const InputDecoration(
-                                          labelText: 'Sasia'),
+                                      decoration: InputDecoration(
+                                          labelText: l10n.quantity),
                                       keyboardType: TextInputType.number),
                                 ),
                                 const SizedBox(width: 12),
                                 Expanded(
                                   child: TextField(
                                       controller: basePriceController,
-                                      decoration: const InputDecoration(
-                                          labelText: 'Çmimi 0% (Opsional)'),
+                                      decoration: InputDecoration(
+                                          labelText: l10n.basePriceOptional),
                                       keyboardType: TextInputType.number),
                                 ),
                               ],
@@ -271,15 +272,15 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                             const SizedBox(height: 12),
                             TextField(
                                 controller: priceController,
-                                decoration: const InputDecoration(
-                                    labelText: 'Çmimi me fitim (Opsional)'),
+                                decoration: InputDecoration(
+                                    labelText: l10n.priceOptional),
                                 keyboardType: TextInputType.number),
                             const SizedBox(height: 12),
                             DropdownButtonFormField<int>(
                               value: profileSetIndex,
                               isExpanded: true,
                               decoration:
-                                  const InputDecoration(labelText: 'Profili'),
+                                  InputDecoration(labelText: l10n.catalogProfile),
                               items: [
                                 for (int i = 0; i < profileSetBox.length; i++)
                                   DropdownMenuItem<int>(
@@ -298,7 +299,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                               value: glassIndex,
                               isExpanded: true,
                               decoration:
-                                  const InputDecoration(labelText: 'Xhami'),
+                                  InputDecoration(labelText: l10n.catalogGlass),
                               items: [
                                 for (int i = 0; i < glassBox.length; i++)
                                   DropdownMenuItem<int>(
@@ -327,8 +328,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                                 Expanded(
                                   child: TextField(
                                       controller: verticalController,
-                                      decoration: const InputDecoration(
-                                          labelText: 'Sektorë Vertikal'),
+                                      decoration: InputDecoration(
+                                          labelText: l10n.verticalSections),
                                       keyboardType: TextInputType.number,
                                       onChanged: (_) => _updateGrid()),
                                 ),
@@ -336,8 +337,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                                 Expanded(
                                   child: TextField(
                                       controller: horizontalController,
-                                      decoration: const InputDecoration(
-                                          labelText: 'Sektorë Horizontal'),
+                                      decoration: InputDecoration(
+                                          labelText: l10n.horizontalSections),
                                       keyboardType: TextInputType.number,
                                       onChanged: (_) => _updateGrid()),
                                 ),
@@ -362,15 +363,15 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                                 Expanded(
                                   child: TextField(
                                       controller: extra1DescController,
-                                      decoration: const InputDecoration(
-                                          labelText: 'Emri i shtesës 1')),
+                                      decoration: InputDecoration(
+                                          labelText: l10n.extra1Name)),
                                 ),
                                 const SizedBox(width: 12),
                                 Expanded(
                                   child: TextField(
                                       controller: extra1Controller,
-                                      decoration: const InputDecoration(
-                                          labelText: 'Çmimi i shtesës 1'),
+                                      decoration: InputDecoration(
+                                          labelText: l10n.extra1Price),
                                       keyboardType: TextInputType.number),
                                 ),
                               ],
@@ -381,15 +382,15 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                                 Expanded(
                                   child: TextField(
                                       controller: extra2DescController,
-                                      decoration: const InputDecoration(
-                                          labelText: 'Emri i shtesës 2')),
+                                      decoration: InputDecoration(
+                                          labelText: l10n.extra2Name)),
                                 ),
                                 const SizedBox(width: 12),
                                 Expanded(
                                   child: TextField(
                                       controller: extra2Controller,
-                                      decoration: const InputDecoration(
-                                          labelText: 'Çmimi i shtesës 2'),
+                                      decoration: InputDecoration(
+                                          labelText: l10n.extra2Price),
                                       keyboardType: TextInputType.number),
                                 ),
                               ],
@@ -398,20 +399,20 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                             TextField(
                               controller: notesController,
                               decoration:
-                                  const InputDecoration(labelText: 'Shënime'),
+                                  InputDecoration(labelText: l10n.notes),
                               maxLines: 2,
                             ),
                             const SizedBox(height: 12),
                             DropdownButtonFormField<int?>(
                               value: mechanismIndex,
                               isExpanded: true,
-                              decoration: const InputDecoration(
-                                  labelText: 'Mekanizmi (Opsional)'),
+                              decoration: InputDecoration(
+                                  labelText: l10n.mechanismOptional),
                               items: [
-                                const DropdownMenuItem<int?>(
+                                DropdownMenuItem<int?>(
                                     value: null,
                                     child: Text(
-                                      'Asnjë',
+                                      l10n.none,
                                       overflow: TextOverflow.ellipsis,
                                     )),
                                 for (int i = 0; i < mechanismBox.length; i++)
@@ -430,13 +431,13 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                             DropdownButtonFormField<int?>(
                               value: blindIndex,
                               isExpanded: true,
-                              decoration: const InputDecoration(
-                                  labelText: 'Roleta (Opsional)'),
+                              decoration: InputDecoration(
+                                  labelText: l10n.blindOptional),
                               items: [
-                                const DropdownMenuItem<int?>(
+                                DropdownMenuItem<int?>(
                                     value: null,
                                     child: Text(
-                                      'Asnjë',
+                                      l10n.none,
                                       overflow: TextOverflow.ellipsis,
                                     )),
                                 for (int i = 0; i < blindBox.length; i++)
@@ -455,13 +456,13 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                             DropdownButtonFormField<int?>(
                               value: accessoryIndex,
                               isExpanded: true,
-                              decoration: const InputDecoration(
-                                  labelText: 'Aksesor (Opsional)'),
+                              decoration: InputDecoration(
+                                  labelText: l10n.accessoryOptional),
                               items: [
-                                const DropdownMenuItem<int?>(
+                                DropdownMenuItem<int?>(
                                     value: null,
                                     child: Text(
-                                      'Asnjë',
+                                      l10n.none,
                                       overflow: TextOverflow.ellipsis,
                                     )),
                                 for (int i = 0; i < accessoryBox.length; i++)
@@ -487,8 +488,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                           Navigator.pop(context);
                         }
                       },
-                      child:
-                          Text(widget.existingItem == null ? 'Shto' : 'Ruaj'),
+                      child: Text(
+                          widget.existingItem == null ? l10n.add : l10n.save),
                     ),
                   ],
                 ),
@@ -497,6 +498,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
   }
 
   bool _saveItem() {
+    final l10n = AppLocalizations.of(context)!;
     final name = nameController.text.trim();
     final width = int.tryParse(widthController.text) ?? 0;
     final height = int.tryParse(heightController.text) ?? 0;
@@ -507,9 +509,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
 
     if (name.isEmpty || width <= 0 || height <= 0) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-            content:
-                Text('Ju lutem plotësoni të gjitha të dhënat e kërkuara!')),
+        SnackBar(content: Text(l10n.fillAllRequired)),
       );
       return false;
     }
@@ -548,20 +548,20 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
   }
 
   Future<bool> _onWillPop() async {
+    final l10n = AppLocalizations.of(context)!;
     final shouldSave = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Ruaj ndryshimet?'),
-        content:
-            const Text('Dëshironi t\'i ruani ndryshimet para se të dilni?'),
+        title: Text(l10n.saveChanges),
+        content: Text(l10n.saveChangesQuestion),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Jo'),
+            child: Text(l10n.no),
           ),
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Po'),
+            child: Text(l10n.yes),
           ),
         ],
       ),
@@ -670,11 +670,11 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
           horizontalAdapters.sublist(0, horizontalSections - 1);
     }
 
-    _recalculateWidths();
-    _recalculateHeights();
+    _recalculateWidths(showErrors: false);
+    _recalculateHeights(showErrors: false);
   }
 
-  void _recalculateWidths() {
+  void _recalculateWidths({bool showErrors = true}) {
     if (verticalSections == 0) return;
     int totalWidth = int.tryParse(widthController.text) ?? 0;
     int specifiedSum = 0;
@@ -689,10 +689,12 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
     }
     int remaining = totalWidth - specifiedSum;
     if (remaining < 0) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-            content: Text('Gjerësia e sektorit e kalon gjerësinë totale!')),
-      );
+      if (showErrors && mounted) {
+        final l10n = AppLocalizations.of(context)!;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.sectionWidthExceeds)),
+        );
+      }
       remaining = 0;
     }
     int autoWidth = (unspecified + 1) > 0 ? remaining ~/ (unspecified + 1) : 0;
@@ -713,7 +715,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
     if (mounted) setState(() {});
   }
 
-  void _recalculateHeights() {
+  void _recalculateHeights({bool showErrors = true}) {
     if (horizontalSections == 0) return;
     int totalHeight = int.tryParse(heightController.text) ?? 0;
     int specifiedSum = 0;
@@ -728,10 +730,12 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
     }
     int remaining = totalHeight - specifiedSum;
     if (remaining < 0) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-            content: Text('Lartësia e sektorit e kalon lartësinë totale!')),
-      );
+      if (showErrors && mounted) {
+        final l10n = AppLocalizations.of(context)!;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.sectionHeightExceeds)),
+        );
+      }
       remaining = 0;
     }
     int autoHeight = (unspecified + 1) > 0 ? remaining ~/ (unspecified + 1) : 0;
@@ -753,6 +757,7 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
   }
 
   Widget _buildGrid() {
+    final l10n = AppLocalizations.of(context)!;
     return Column(
       children: [
         if (verticalSections > 0)
@@ -803,8 +808,8 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                         child: Center(
                           child: Text(
                             fixedSectors[r * verticalSections + c]
-                                ? 'Fikse'
-                                : 'Me hapje (Me krah)',
+                                ? l10n.fixed
+                                : l10n.openWithSash,
                           ),
                         ),
                       ),
@@ -818,20 +823,21 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
   }
 
   Widget _buildDimensionInputs() {
+    final l10n = AppLocalizations.of(context)!;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (verticalSections > 0)
           Text(verticalSections > 1
-              ? 'Gjerësitë e sektorëve (mm)'
-              : 'Gjerësia e sektorit (mm)'),
+              ? l10n.sectorWidths
+              : l10n.sectorWidth),
         for (int i = 0; i < verticalSections; i++)
           TextField(
             controller: sectionWidthCtrls[i],
             decoration: InputDecoration(
               labelText: i == verticalSections - 1
-                  ? 'Gjerësia ${i + 1} (auto)'
-                  : 'Gjerësia ${i + 1}',
+                  ? l10n.widthAutoLabel(i + 1)
+                  : l10n.widthLabel(i + 1),
             ),
             keyboardType: TextInputType.number,
             enabled: i < verticalSections - 1,
@@ -841,15 +847,15 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
         if (horizontalSections > 0) const SizedBox(height: 8),
         if (horizontalSections > 0)
           Text(horizontalSections > 1
-              ? 'Lartësitë e sektorëve (mm)'
-              : 'Lartësia e sektorit (mm)'),
+              ? l10n.sectorHeights
+              : l10n.sectorHeight),
         for (int i = 0; i < horizontalSections; i++)
           TextField(
             controller: sectionHeightCtrls[i],
             decoration: InputDecoration(
               labelText: i == horizontalSections - 1
-                  ? 'Lartësia ${i + 1} (auto)'
-                  : 'Lartësia ${i + 1}',
+                  ? l10n.heightAutoLabel(i + 1)
+                  : l10n.heightLabel(i + 1),
             ),
             keyboardType: TextInputType.number,
             enabled: i < horizontalSections - 1,
@@ -858,25 +864,25 @@ class _WindowDoorItemPageState extends State<WindowDoorItemPage> {
                 : null,
           ),
         if (verticalSections > 1) const SizedBox(height: 8),
-        if (verticalSections > 1) const Text('Ndarja Vertikale'),
+        if (verticalSections > 1) Text(l10n.verticalDivision),
         for (int i = 0; i < verticalSections - 1; i++)
           DropdownButton<bool>(
             value: verticalAdapters[i],
-            items: const [
-              DropdownMenuItem(value: false, child: Text('T')),
-              DropdownMenuItem(value: true, child: Text('Adapter')),
+            items: [
+              const DropdownMenuItem(value: false, child: Text('T')),
+              DropdownMenuItem(value: true, child: Text(l10n.pdfAdapter)),
             ],
             onChanged: (val) =>
                 setState(() => verticalAdapters[i] = val ?? false),
           ),
         if (horizontalSections > 1) const SizedBox(height: 8),
-        if (horizontalSections > 1) const Text('Ndarja Horizontale'),
+        if (horizontalSections > 1) Text(l10n.horizontalDivision),
         for (int i = 0; i < horizontalSections - 1; i++)
           DropdownButton<bool>(
             value: horizontalAdapters[i],
-            items: const [
-              DropdownMenuItem(value: false, child: Text('T')),
-              DropdownMenuItem(value: true, child: Text('Adapter')),
+            items: [
+              const DropdownMenuItem(value: false, child: Text('T')),
+              DropdownMenuItem(value: true, child: Text(l10n.pdfAdapter)),
             ],
             onChanged: (val) =>
                 setState(() => horizontalAdapters[i] = val ?? false),


### PR DESCRIPTION
## Summary
- replace hard-coded text in window_door_item_page with localized strings
- add localization entries and helpers for window/door item labels in all supported languages
- avoid early localization lookups during grid setup to prevent crashes when adding or editing items
- add missing Albanian translations for offer-related strings to avoid Offers page crashes

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe4c8522c8324aef18da3ad811970