### PR TITLE
Localize catalog tab headers

### DIFF
--- a/lib/pages/catalog_tab_page.dart
+++ b/lib/pages/catalog_tab_page.dart
@@ -6,6 +6,7 @@ import 'catalogs_page.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_background.dart';
 import '../widgets/glass_card.dart';
+import '../l10n/app_localizations.dart';
 
 class CatalogTabPage extends StatefulWidget {
   final CatalogType type;
@@ -670,25 +671,26 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
     );
   }
 
-  String _typeLabel() {
+  String _typeLabel(AppLocalizations l10n) {
     switch (widget.type) {
       case CatalogType.profileSet:
-        return "Profile";
+        return l10n.catalogProfile;
       case CatalogType.glass:
-        return "Glass";
+        return l10n.catalogGlass;
       case CatalogType.blind:
-        return "Roller Shutter";
+        return l10n.catalogBlind;
       case CatalogType.mechanism:
-        return "Mechanism";
+        return l10n.catalogMechanism;
       case CatalogType.accessory:
-        return "Accessory";
+        return l10n.catalogAccessory;
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: Text(_typeLabel())),
+      appBar: AppBar(title: Text(_typeLabel(l10n))),
       body: AppBackground(
         child: ValueListenableBuilder(
           valueListenable: box.listenable(),


### PR DESCRIPTION
## Summary
- use localized labels for the catalog tab headers so they reflect the selected language

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18197d1848324a8094086a351a29b