### PR TITLE
Fix Flutter localization configuration

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,4 +1,3 @@
 arb-dir: lib/l10n
 template-arb-file: app_sq.arb
 output-localization-file: app_localizations.dart
-synthetic-package: false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,8 @@ flutter_icons:
 # The following section is specific to Flutter packages.
 flutter:
 
+  generate: true
+
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
## Summary
- remove the deprecated `synthetic-package` option from the localization settings
- enable Flutter localization code generation in `pubspec.yaml`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d2c3984c8324b51306421c93bb52