### PR TITLE
Enhance cutting optimizer with offer labels

### DIFF
--- a/lib/pdf/production_pdf.dart
+++ b/lib/pdf/production_pdf.dart
@@ -7,6 +7,7 @@ import 'package:printing/printing.dart';
 
 import '../l10n/app_localizations.dart';
 import '../models.dart';
+import '../utils/production_piece_detail.dart';
 
 Future<pw.ThemeData> _loadPdfTheme() async {
   final baseFontData = await rootBundle.load('assets/fonts/Montserrat-Regular.ttf');
@@ -343,7 +344,7 @@ Future<void> exportHekriResultsPdf({
 }
 
 Future<void> exportCuttingResultsPdf<T>({
-  required Map<int, Map<T, List<List<int>>>> results,
+  required Map<int, Map<T, List<List<ProductionPieceDetail>>>> results,
   required Map<T, String> pieceLabels,
   required List<T> typeOrder,
   required Box<ProfileSet> profileBox,
@@ -400,8 +401,9 @@ Future<void> exportCuttingResultsPdf<T>({
                           pw.SizedBox(height: 6),
                           () {
                             final bars = typeMap[type]!;
-                            final needed =
-                                bars.expand((bar) => bar).fold<int>(0, (a, b) => a + b);
+                            final needed = bars
+                                .expand((bar) => bar)
+                                .fold<int>(0, (a, b) => a + b.length);
                             final totalLen = bars.length * pipeLen;
                             final waste = totalLen - needed;
                             return pw.Column(
@@ -418,9 +420,12 @@ Future<void> exportCuttingResultsPdf<T>({
                                 pw.SizedBox(height: 6),
                                 ...List.generate(bars.length, (index) {
                                   final bar = bars[index];
-                                  final combination = bar.join(' + ');
-                                  final total =
-                                      bar.fold<int>(0, (a, b) => a + b);
+                                  final combination = bar
+                                      .map((piece) =>
+                                          '${piece.length} (${piece.offerLabel})')
+                                      .join(' + ');
+                                  final total = bar.fold<int>(
+                                      0, (a, b) => a + b.length);
                                   return pw.Container(
                                     margin:
                                         const pw.EdgeInsets.symmetric(vertical: 3),

--- a/lib/utils/offer_label.dart
+++ b/lib/utils/offer_label.dart
@@ -1,0 +1,23 @@
+import 'package:hive/hive.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models.dart';
+
+String buildOfferLabel(
+  AppLocalizations l10n,
+  Box<Customer> customerBox,
+  int offerIndex,
+  Offer? offer,
+) {
+  final customerName = (offer != null &&
+          offer.customerIndex >= 0 &&
+          offer.customerIndex < customerBox.length)
+      ? customerBox.getAt(offer.customerIndex)?.name.trim() ?? ''
+      : '';
+
+  if (customerName.isNotEmpty) {
+    return '${l10n.pdfOffer} ${offerIndex + 1} • $customerName';
+  }
+
+  return '${l10n.pdfOffer} ${offerIndex + 1}';
+}

--- a/lib/utils/production_piece_detail.dart
+++ b/lib/utils/production_piece_detail.dart
@@ -1,0 +1,11 @@
+class ProductionPieceDetail {
+  const ProductionPieceDetail({
+    required this.length,
+    required this.offerIndex,
+    required this.offerLabel,
+  });
+
+  final int length;
+  final int offerIndex;
+  final String offerLabel;
+}

--- a/lib/widgets/offer_multi_select.dart
+++ b/lib/widgets/offer_multi_select.dart
@@ -3,6 +3,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import '../l10n/app_localizations.dart';
 import '../models.dart';
+import '../utils/offer_label.dart';
 
 class OfferMultiSelectField extends StatelessWidget {
   const OfferMultiSelectField({
@@ -55,6 +56,7 @@ class _OfferSelectorContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
+    final customerBox = Hive.box<Customer>('customers');
     final sortedSelection = selectedOffers.toList()
       ..sort((a, b) {
         final offerA = offerBox.getAt(a);
@@ -81,7 +83,10 @@ class _OfferSelectorContent extends StatelessWidget {
     const maxVisible = 3;
 
     for (int i = 0; i < sortedSelection.length && i < maxVisible; i++) {
-      chips.add(Chip(label: Text('${l10n.pdfOffer} ${sortedSelection[i] + 1}')));
+      final offerIndex = sortedSelection[i];
+      final offer = offerBox.getAt(offerIndex);
+      final label = buildOfferLabel(l10n, customerBox, offerIndex, offer);
+      chips.add(Chip(label: Text(label)));
     }
 
     if (sortedSelection.length > maxVisible) {
@@ -140,7 +145,7 @@ class _OfferSelectorContent extends StatelessWidget {
                         offer.customerIndex < customerBox.length)
                     ? customerBox.getAt(offer.customerIndex)?.name ?? ''
                     : '';
-                final label = '${l10n.pdfOffer} ${i + 1}';
+                final label = buildOfferLabel(l10n, customerBox, i, offer);
                 final combinedText = '$label $customerName ${offer?.notes ?? ''}';
                 if (query.isEmpty ||
                     combinedText.toLowerCase().contains(query)) {
@@ -220,6 +225,8 @@ class _OfferSelectorContent extends StatelessWidget {
                                     ? customerBox.getAt(offer.customerIndex)
                                     : null;
 
+                                final label = buildOfferLabel(
+                                    l10n, customerBox, offerIndex, offer);
                                 return CheckboxListTile(
                                   value: tempSelection.contains(offerIndex),
                                   onChanged: (selected) {
@@ -231,7 +238,7 @@ class _OfferSelectorContent extends StatelessWidget {
                                       }
                                     });
                                   },
-                                  title: Text('${l10n.pdfOffer} ${offerIndex + 1}'),
+                                  title: Text(label),
                                   subtitle: Column(
                                     mainAxisSize: MainAxisSize.min,
                                     crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## Summary
- track cutting pieces with their originating offer and share a helper for consistent offer labels
- show labeled chips in the cutting optimizer UI to differentiate combined offers
- include the offer labels when exporting cutting optimization PDFs

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e560184e948324b2bf483ffe74c157