### PR TITLE
Add offer letter legend to cutting optimizer page

### DIFF
--- a/lib/utils/production_piece_detail.dart
+++ b/lib/utils/production_piece_detail.dart
@@ -3,9 +3,11 @@ class ProductionPieceDetail {
     required this.length,
     required this.offerIndex,
     required this.offerLabel,
+    required this.offerLetter,
   });
 
   final int length;
   final int offerIndex;
   final String offerLabel;
+  final String offerLetter;
 }


### PR DESCRIPTION
## Summary
- assign alphabetic labels to the selected offers and persist them across calculations
- display a legend table mapping each letter to its offer and shorten chip labels to the letter while keeping a tooltip with the full name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5646473288324be467ba1afcba1b6