### PR TITLE
Display bar labels inline with dimensions

### DIFF
--- a/lib/pages/cutting_optimizer_page.dart
+++ b/lib/pages/cutting_optimizer_page.dart
@@ -373,37 +373,17 @@ class _CuttingOptimizerPageState extends State<CuttingOptimizerPage> {
                               Padding(
                                 padding:
                                     const EdgeInsets.symmetric(vertical: 2),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      l10n.productionBarDetail(
-                                        i + 1,
-                                        bars[i]
-                                            .map((piece) => piece.length)
-                                            .join(' + '),
-                                        bars[i].fold<int>(
-                                            0, (a, b) => a + b.length),
-                                        pipeLen,
-                                      ),
-                                    ),
-                                    const SizedBox(height: 4),
-                                    Wrap(
-                                      spacing: 6,
-                                      runSpacing: 6,
-                                      children: [
-                                        for (final piece in bars[i])
-                                          Tooltip(
-                                            message: piece.offerLabel,
-                                            child: Chip(
-                                              label: Text(
-                                                '${piece.offerLetter} (${piece.length})',
-                                              ),
-                                            ),
-                                          ),
-                                      ],
-                                    ),
-                                  ],
+                                child: Text(
+                                  l10n.productionBarDetail(
+                                    i + 1,
+                                    bars[i]
+                                        .map((piece) =>
+                                            '${piece.length} (${piece.offerLetter})')
+                                        .join(' + '),
+                                    bars[i].fold<int>(
+                                        0, (a, b) => a + b.length),
+                                    pipeLen,
+                                  ),
                                 ),
                               ),
                             const SizedBox(height: 8),

--- a/lib/pdf/production_pdf.dart
+++ b/lib/pdf/production_pdf.dart
@@ -422,7 +422,7 @@ Future<void> exportCuttingResultsPdf<T>({
                                   final bar = bars[index];
                                   final combination = bar
                                       .map((piece) =>
-                                          '${piece.length} (${piece.offerLabel})')
+                                          '${piece.length} (${piece.offerLetter})')
                                       .join(' + ');
                                   final total = bar.fold<int>(
                                       0, (a, b) => a + b.length);


### PR DESCRIPTION
## Summary
- show the offer letter alongside each cut length in the cutting optimizer details
- remove the extra chips so the bar detail string now includes both length and letter
- align the PDF export to use the same inline length-and-letter formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e567cb60088324911b71ce22910d3a