### PR TITLE
Enhance production PDFs with company and client info

### DIFF
--- a/lib/pages/cutting_optimizer_page.dart
+++ b/lib/pages/cutting_optimizer_page.dart
@@ -141,7 +141,25 @@ class _CuttingOptimizerPageState extends State<CuttingOptimizerPage> {
       typeOrder: PieceType.values,
       profileBox: profileBox,
       l10n: l10n,
+      clients: _selectedClients(),
     );
+  }
+
+  List<Customer> _selectedClients() {
+    final clients = <Customer>[];
+    final seen = <int>{};
+    for (final offerIndex in selectedOffers) {
+      final offer = offerBox.getAt(offerIndex);
+      if (offer == null) continue;
+      final index = offer.customerIndex;
+      if (index < 0 || index >= customerBox.length) continue;
+      if (!seen.add(index)) continue;
+      final customer = customerBox.getAt(index);
+      if (customer != null) {
+        clients.add(customer);
+      }
+    }
+    return clients;
   }
 
   Map<PieceType, List<int>> _pieceLengths(WindowDoorItem item, ProfileSet set,

--- a/lib/pages/hekri_page.dart
+++ b/lib/pages/hekri_page.dart
@@ -21,6 +21,7 @@ enum PieceType { l, z, t }
 class _HekriPageState extends State<HekriPage> {
   late Box<Offer> offerBox;
   late Box<ProfileSet> profileBox;
+  late Box<Customer> customerBox;
   final Set<int> selectedOffers = <int>{};
   Map<int, List<List<int>>>? results;
 
@@ -29,6 +30,7 @@ class _HekriPageState extends State<HekriPage> {
     super.initState();
     offerBox = Hive.box<Offer>('offers');
     profileBox = Hive.box<ProfileSet>('profileSets');
+    customerBox = Hive.box<Customer>('customers');
   }
 
   void _openProfiles() {
@@ -97,7 +99,25 @@ class _HekriPageState extends State<HekriPage> {
       results: data,
       profileBox: profileBox,
       l10n: l10n,
+      clients: _selectedClients(),
     );
+  }
+
+  List<Customer> _selectedClients() {
+    final clients = <Customer>[];
+    final seen = <int>{};
+    for (final offerIndex in selectedOffers) {
+      final offer = offerBox.getAt(offerIndex);
+      if (offer == null) continue;
+      final index = offer.customerIndex;
+      if (index < 0 || index >= customerBox.length) continue;
+      if (!seen.add(index)) continue;
+      final customer = customerBox.getAt(index);
+      if (customer != null) {
+        clients.add(customer);
+      }
+    }
+    return clients;
   }
 
   Map<PieceType, List<int>> _pieceLengths(WindowDoorItem item, ProfileSet set,

--- a/lib/pages/roleta_page.dart
+++ b/lib/pages/roleta_page.dart
@@ -18,6 +18,7 @@ class RoletaPage extends StatefulWidget {
 class _RoletaPageState extends State<RoletaPage> {
   late Box<Offer> offerBox;
   late Box<Blind> blindBox;
+  late Box<Customer> customerBox;
   final Set<int> selectedOffers = <int>{};
   Map<int, Map<String, int>>? results; // blindIndex -> size -> qty
 
@@ -26,6 +27,7 @@ class _RoletaPageState extends State<RoletaPage> {
     super.initState();
     offerBox = Hive.box<Offer>('offers');
     blindBox = Hive.box<Blind>('blinds');
+    customerBox = Hive.box<Customer>('customers');
   }
 
   void _calculate() {
@@ -59,7 +61,25 @@ class _RoletaPageState extends State<RoletaPage> {
       results: data,
       blindBox: blindBox,
       l10n: l10n,
+      clients: _selectedClients(),
     );
+  }
+
+  List<Customer> _selectedClients() {
+    final clients = <Customer>[];
+    final seen = <int>{};
+    for (final offerIndex in selectedOffers) {
+      final offer = offerBox.getAt(offerIndex);
+      if (offer == null) continue;
+      final index = offer.customerIndex;
+      if (index < 0 || index >= customerBox.length) continue;
+      if (!seen.add(index)) continue;
+      final customer = customerBox.getAt(index);
+      if (customer != null) {
+        clients.add(customer);
+      }
+    }
+    return clients;
   }
 
   @override

--- a/lib/pages/xhami_page.dart
+++ b/lib/pages/xhami_page.dart
@@ -20,6 +20,7 @@ class _XhamiPageState extends State<XhamiPage> {
   late Box<Glass> glassBox;
   late Box<Blind> blindBox;
   late Box<ProfileSet> profileBox;
+  late Box<Customer> customerBox;
   final Set<int> selectedOffers = <int>{};
   Map<int, Map<String, int>>? results; // glassIndex -> size -> qty
 
@@ -30,6 +31,7 @@ class _XhamiPageState extends State<XhamiPage> {
     glassBox = Hive.box<Glass>('glasses');
     blindBox = Hive.box<Blind>('blinds');
     profileBox = Hive.box<ProfileSet>('profileSets');
+    customerBox = Hive.box<Customer>('customers');
   }
 
   void _calculate() {
@@ -70,7 +72,25 @@ class _XhamiPageState extends State<XhamiPage> {
       results: data,
       glassBox: glassBox,
       l10n: l10n,
+      clients: _selectedClients(),
     );
+  }
+
+  List<Customer> _selectedClients() {
+    final clients = <Customer>[];
+    final seen = <int>{};
+    for (final offerIndex in selectedOffers) {
+      final offer = offerBox.getAt(offerIndex);
+      if (offer == null) continue;
+      final index = offer.customerIndex;
+      if (index < 0 || index >= customerBox.length) continue;
+      if (!seen.add(index)) continue;
+      final customer = customerBox.getAt(index);
+      if (customer != null) {
+        clients.add(customer);
+      }
+    }
+    return clients;
   }
 
   List<List<int>> _glassSizes(WindowDoorItem item, ProfileSet set,


### PR DESCRIPTION
## Summary
- restyle the production PDF header to show company details and selected clients
- allow production PDF exports to receive client lists and surface them in the header
- surface customer information from the selected offers across production tools when generating PDFs

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e569ce2b848324817d6d2ba4fc280f