### PR TITLE
Allow customizing hekur profile length

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -14,6 +14,7 @@
   "productionCutSummary": "Benötigt {needed} m, Rohre: {pipes}, Verschnitt {waste} m",
   "productionBarDetail": "Stab {index}: {combination} = {total}/{pipeLength}",
   "productionOffsetFrom": "Versatz von {type} (mm)",
+  "productionProfileLength": "Profillänge (mm)",
   "productionOffsetsSummary": "L: {l}mm, Z: {z}mm, T: {t}mm",
   "cuttingPieceFrame": "Rahmen (L)",
   "cuttingPieceSash": "Flügel (Z)",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -14,6 +14,7 @@
   "productionCutSummary": "Needed {needed} m, Pipes: {pipes}, Waste {waste} m",
   "productionBarDetail": "Bar {index}: {combination} = {total}/{pipeLength}",
   "productionOffsetFrom": "Offset from {type} (mm)",
+  "productionProfileLength": "Profile length (mm)",
   "productionOffsetsSummary": "L: {l}mm, Z: {z}mm, T: {t}mm",
   "cuttingPieceFrame": "Frame (L)",
   "cuttingPieceSash": "Sash (Z)",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -14,6 +14,7 @@
   "productionCutSummary": "Nécessaire {needed} m, Tubes : {pipes}, Perte {waste} m",
   "productionBarDetail": "Barre {index} : {combination} = {total}/{pipeLength}",
   "productionOffsetFrom": "Décalage depuis {type} (mm)",
+  "productionProfileLength": "Longueur du profil (mm)",
   "productionOffsetsSummary": "L : {l}mm, Z : {z}mm, T : {t}mm",
   "cuttingPieceFrame": "Cadre (L)",
   "cuttingPieceSash": "Ouvrant (Z)",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -14,6 +14,7 @@
   "productionCutSummary": "Necessari {needed} m, Tubi: {pipes}, Scarto {waste} m",
   "productionBarDetail": "Barra {index}: {combination} = {total}/{pipeLength}",
   "productionOffsetFrom": "Offset da {type} (mm)",
+  "productionProfileLength": "Lunghezza del profilo (mm)",
   "productionOffsetsSummary": "L: {l}mm, Z: {z}mm, T: {t}mm",
   "cuttingPieceFrame": "Telaio (L)",
   "cuttingPieceSash": "Anta (Z)",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -23,6 +23,7 @@ class AppLocalizations {
       'productionBarDetail':
           'Shufra {index}: {combination} = {total}/{pipeLength}',
       'productionOffsetFrom': 'Offset nga {type} (mm)',
+      'productionProfileLength': 'Gjatësia e profilit (mm)',
       'productionOffsetsSummary':
           'L: {l}mm, Z: {z}mm, T: {t}mm',
       'cuttingPieceFrame': 'Korniza (L)',
@@ -210,6 +211,7 @@ class AppLocalizations {
       'productionBarDetail':
           'Bar {index}: {combination} = {total}/{pipeLength}',
       'productionOffsetFrom': 'Offset from {type} (mm)',
+      'productionProfileLength': 'Profile length (mm)',
       'productionOffsetsSummary':
           'L: {l}mm, Z: {z}mm, T: {t}mm',
       'cuttingPieceFrame': 'Frame (L)',
@@ -391,6 +393,7 @@ class AppLocalizations {
       'productionBarDetail':
           'Stab {index}: {combination} = {total}/{pipeLength}',
       'productionOffsetFrom': 'Versatz von {type} (mm)',
+      'productionProfileLength': 'Profillänge (mm)',
       'productionOffsetsSummary':
           'L: {l}mm, Z: {z}mm, T: {t}mm',
       'cuttingPieceFrame': 'Rahmen (L)',
@@ -576,6 +579,7 @@ class AppLocalizations {
       'productionBarDetail':
           'Barre {index} : {combination} = {total}/{pipeLength}',
       'productionOffsetFrom': 'Décalage depuis {type} (mm)',
+      'productionProfileLength': 'Longueur du profil (mm)',
       'productionOffsetsSummary':
           'L : {l}mm, Z : {z}mm, T : {t}mm',
       'cuttingPieceFrame': 'Cadre (L)',
@@ -761,6 +765,7 @@ class AppLocalizations {
       'productionBarDetail':
           'Barra {index}: {combination} = {total}/{pipeLength}',
       'productionOffsetFrom': 'Offset da {type} (mm)',
+      'productionProfileLength': 'Lunghezza del profilo (mm)',
       'productionOffsetsSummary':
           'L: {l}mm, Z: {z}mm, T: {t}mm',
       'cuttingPieceFrame': 'Telaio (L)',
@@ -966,6 +971,8 @@ class AppLocalizations {
 
   String productionOffsetFrom(String type) =>
       _t('productionOffsetFrom').replaceAll('{type}', type);
+
+  String get productionProfileLength => _t('productionProfileLength');
 
   String productionOffsetsSummary(int l, int z, int t) {
     final template = _t('productionOffsetsSummary');

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -14,6 +14,7 @@
   "productionCutSummary": "Nevojiten {needed} m, Tuba: {pipes}, Humbje {waste} m",
   "productionBarDetail": "Shufra {index}: {combination} = {total}/{pipeLength}",
   "productionOffsetFrom": "Offset nga {type} (mm)",
+  "productionProfileLength": "Gjatësia e profilit (mm)",
   "productionOffsetsSummary": "L: {l}mm, Z: {z}mm, T: {t}mm",
   "cuttingPieceFrame": "Korniza (L)",
   "cuttingPieceSash": "Krah (Z)",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -189,6 +189,12 @@ abstract class AppLocalizations {
   /// **'Offset from {type} (mm)'**
   String productionOffsetFrom(Object type);
 
+  /// No description provided for @productionProfileLength.
+  ///
+  /// In en, this message translates to:
+  /// **'Profile length (mm)'**
+  String get productionProfileLength;
+
   /// No description provided for @productionOffsetsSummary.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -58,6 +58,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get productionProfileLength => 'Profillänge (mm)';
+
+  @override
   String productionOffsetsSummary(Object l, Object t, Object z) {
     return 'L: ${l}mm, Z: ${z}mm, T: ${t}mm';
   }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -58,6 +58,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get productionProfileLength => 'Profile length (mm)';
+
+  @override
   String productionOffsetsSummary(Object l, Object t, Object z) {
     return 'L: ${l}mm, Z: ${z}mm, T: ${t}mm';
   }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -58,6 +58,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get productionProfileLength => 'Longueur du profil (mm)';
+
+  @override
   String productionOffsetsSummary(Object l, Object t, Object z) {
     return 'L : ${l}mm, Z : ${z}mm, T : ${t}mm';
   }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -58,6 +58,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get productionProfileLength => 'Lunghezza del profilo (mm)';
+
+  @override
   String productionOffsetsSummary(Object l, Object t, Object z) {
     return 'L: ${l}mm, Z: ${z}mm, T: ${t}mm';
   }

--- a/lib/l10n/generated/app_localizations_sq.dart
+++ b/lib/l10n/generated/app_localizations_sq.dart
@@ -58,6 +58,9 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
+  String get productionProfileLength => 'Gjatësia e profilit (mm)';
+
+  @override
   String productionOffsetsSummary(Object l, Object t, Object z) {
     return 'L: ${l}mm, Z: ${z}mm, T: ${t}mm';
   }

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -36,7 +36,7 @@ class ProfileSet extends HiveObject {
   double priceAdapter; // Adapter (for double sash)
   @HiveField(5)
   double priceLlajsne; // Glazing bead
-  @HiveField(6, defaultValue: 0)
+  @HiveField(6, defaultValue: 6000)
   int pipeLength; // Standard pipe length in mm
   @HiveField(7, defaultValue: 0)
   int hekriOffsetL; // Hekri length difference for L profile
@@ -84,7 +84,7 @@ class ProfileSet extends HiveObject {
     required this.priceT,
     required this.priceAdapter,
     required this.priceLlajsne,
-    this.pipeLength = 6500,
+    this.pipeLength = 6000,
     this.hekriOffsetL = 0,
     this.hekriOffsetZ = 0,
     this.hekriOffsetT = 0,

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -66,7 +66,7 @@ class ProfileSetAdapter extends TypeAdapter<ProfileSet> {
       priceT: fields[3] as double,
       priceAdapter: fields[4] as double,
       priceLlajsne: fields[5] as double,
-      pipeLength: fields[6] == null ? 0 : fields[6] as int,
+      pipeLength: fields[6] == null ? 6000 : fields[6] as int,
       hekriOffsetL: fields[7] == null ? 0 : fields[7] as int,
       hekriOffsetZ: fields[8] == null ? 0 : fields[8] as int,
       hekriOffsetT: fields[9] == null ? 0 : fields[9] as int,

--- a/lib/pages/catalog_tab_page.dart
+++ b/lib/pages/catalog_tab_page.dart
@@ -333,7 +333,7 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                         priceLlajsne:
                             double.tryParse(priceLlajsneController.text) ?? 0,
                         pipeLength:
-                            int.tryParse(pipeLengthController.text) ?? 6500,
+                            int.tryParse(pipeLengthController.text) ?? 6000,
                         hekriOffsetL: item.hekriOffsetL,
                         hekriOffsetZ: item.hekriOffsetZ,
                         hekriOffsetT: item.hekriOffsetT,
@@ -428,7 +428,7 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
     final priceTController = TextEditingController();
     final priceAdapterController = TextEditingController();
     final priceLlajsneController = TextEditingController();
-    final pipeLengthController = TextEditingController(text: '6500');
+    final pipeLengthController = TextEditingController(text: '6000');
     final massLController = TextEditingController();
     final massZController = TextEditingController();
     final massTController = TextEditingController();
@@ -664,7 +664,7 @@ class _CatalogTabPageState extends State<CatalogTabPage> {
                         double.tryParse(priceAdapterController.text) ?? 0,
                     priceLlajsne:
                         double.tryParse(priceLlajsneController.text) ?? 0,
-                    pipeLength: int.tryParse(pipeLengthController.text) ?? 6500,
+                    pipeLength: int.tryParse(pipeLengthController.text) ?? 6000,
                     massL: double.tryParse(massLController.text) ?? 0,
                     massZ: double.tryParse(massZController.text) ?? 0,
                     massT: double.tryParse(massTController.text) ?? 0,

--- a/lib/pages/cutting_optimizer_page.dart
+++ b/lib/pages/cutting_optimizer_page.dart
@@ -94,7 +94,9 @@ class _CuttingOptimizerPageState extends State<CuttingOptimizerPage> {
     final res = <int, Map<PieceType, List<List<ProductionPieceDetail>>>>{};
 
     piecesMap.forEach((index, typeMap) {
-      final pipeLength = profileBox.getAt(index)?.pipeLength ?? 6500;
+      final profile = profileBox.getAt(index);
+      final pipeLength =
+          profile == null || profile.pipeLength <= 0 ? 6000 : profile.pipeLength;
       final resultTypeMap = <PieceType, List<List<ProductionPieceDetail>>>{};
       typeMap.forEach((type, pieces) {
         if (pieces.isEmpty) return;
@@ -365,7 +367,10 @@ class _CuttingOptimizerPageState extends State<CuttingOptimizerPage> {
               const SizedBox(height: 12),
               ...results!.entries.map((e) {
                 final profile = profileBox.getAt(e.key);
-                final pipeLen = profile?.pipeLength ?? 6500;
+                final pipeLen =
+                    profile == null || profile.pipeLength <= 0
+                        ? 6000
+                        : profile.pipeLength;
                 return GlassCard(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/pages/hekri_page.dart
+++ b/lib/pages/hekri_page.dart
@@ -82,7 +82,9 @@ class _HekriPageState extends State<HekriPage> {
 
     final res = <int, List<List<int>>>{};
     piecesMap.forEach((index, pieces) {
-      final pipeLength = profileBox.getAt(index)?.pipeLength ?? 6500;
+      final profile = profileBox.getAt(index);
+      final pipeLength =
+          profile == null || profile.pipeLength <= 0 ? 6000 : profile.pipeLength;
       if (pieces.isEmpty) return;
       final bars = _packPieces(pieces, pipeLength);
       res[index] = bars;
@@ -280,7 +282,10 @@ class _HekriPageState extends State<HekriPage> {
               const SizedBox(height: 16),
               ...results!.entries.map((e) {
                 final profile = profileBox.getAt(e.key);
-                final pipeLen = profile?.pipeLength ?? 6500;
+                final pipeLen =
+                    profile == null || profile.pipeLength <= 0
+                        ? 6000
+                        : profile.pipeLength;
                 final bars = e.value;
                 final needed =
                     bars.expand((b) => b).fold<int>(0, (a, b) => a + b);

--- a/lib/pages/hekri_profiles_page.dart
+++ b/lib/pages/hekri_profiles_page.dart
@@ -25,6 +25,10 @@ class _HekriProfilesPageState extends State<HekriProfilesPage> {
     final profile = profileBox.getAt(index);
     if (profile == null) return;
     final l10n = AppLocalizations.of(context);
+    final pipeLengthController = TextEditingController(
+        text: profile.pipeLength == 0
+            ? '6000'
+            : profile.pipeLength.toString());
     final offsetLController =
         TextEditingController(text: profile.hekriOffsetL.toString());
     final offsetZController =
@@ -39,6 +43,13 @@ class _HekriProfilesPageState extends State<HekriProfilesPage> {
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            TextField(
+              controller: pipeLengthController,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                labelText: l10n.productionProfileLength,
+              ),
+            ),
             TextField(
               controller: offsetLController,
               keyboardType: TextInputType.number,
@@ -77,7 +88,8 @@ class _HekriProfilesPageState extends State<HekriProfilesPage> {
                   priceT: profile.priceT,
                   priceAdapter: profile.priceAdapter,
                   priceLlajsne: profile.priceLlajsne,
-                  pipeLength: profile.pipeLength,
+                  pipeLength:
+                      int.tryParse(pipeLengthController.text) ?? 6000,
                   hekriOffsetL: int.tryParse(offsetLController.text) ?? 0,
                   hekriOffsetZ: int.tryParse(offsetZController.text) ?? 0,
                   hekriOffsetT: int.tryParse(offsetTController.text) ?? 0,
@@ -125,6 +137,9 @@ class _HekriProfilesPageState extends State<HekriProfilesPage> {
                     children: [
                       Text(profile.name,
                           style: const TextStyle(fontWeight: FontWeight.bold)),
+                      const SizedBox(height: 4),
+                      Text(
+                          '${l10n.productionProfileLength}: ${profile.pipeLength == 0 ? 6000 : profile.pipeLength}'),
                       const SizedBox(height: 4),
                       Text(l10n.productionOffsetsSummary(
                           profile.hekriOffsetL,

--- a/lib/pdf/production_pdf.dart
+++ b/lib/pdf/production_pdf.dart
@@ -419,7 +419,10 @@ Future<void> exportHekriResultsPdf({
 
         for (final entry in entries) {
           final profile = profileBox.getAt(entry.key);
-          final pipeLen = profile?.pipeLength ?? 6500;
+          final pipeLen =
+              profile == null || profile.pipeLength <= 0
+                  ? 6000
+                  : profile.pipeLength;
           final bars = entry.value;
           final needed = bars.expand((bar) => bar).fold<int>(0, (a, b) => a + b);
           final totalLen = bars.length * pipeLen;
@@ -512,7 +515,10 @@ Future<void> exportCuttingResultsPdf<T>({
 
         for (final entry in entries) {
           final profile = profileBox.getAt(entry.key);
-          final pipeLen = profile?.pipeLength ?? 6500;
+          final pipeLen =
+              profile == null || profile.pipeLength <= 0
+                  ? 6000
+                  : profile.pipeLength;
           final typeMap = entry.value;
 
           widgets.add(


### PR DESCRIPTION
## Summary
- allow hekur registered profiles to edit pipe length with a 6000 mm default and display the value in the list
- update profile length defaults across cutting calculations, PDFs, and catalog flows to honor the new default when unset
- add localization strings for the new profile length label in all supported languages

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e65088155c8324b12b84dcc7abbca6